### PR TITLE
Added label as read only property

### DIFF
--- a/lib/rtc_data_channel.dart
+++ b/lib/rtc_data_channel.dart
@@ -86,6 +86,9 @@ class RTCDataChannel {
   /// Get current state.
   RTCDataChannelState get state => _state;
 
+  /// Get label.
+  String get label => _label;
+
   /// Event handler for datachannel state changes.
   /// Assign this property to listen for state changes.
   /// Will be passed one argument, [state], which is an [RTCDataChannelState].


### PR DESCRIPTION
The https://developer.mozilla.org/en-US/docs/Web/API/RTCDataChannel specification provides read-only label for the data channel. Added a getter to get the label