### PR TITLE
fix android getsources error

### DIFF
--- a/android/src/main/java/com/cloudwebrtc/webrtc/MethodCallHandlerImpl.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/MethodCallHandlerImpl.java
@@ -949,7 +949,11 @@ public class MethodCallHandlerImpl implements MethodCallHandler, StateProvider {
     audio.putString("facing", "");
     audio.putString("kind", "audioinput");
     array.pushMap(audio);
-    result.success(array);
+    
+    ConstraintsMap map = new ConstraintsMap();
+    map.putArray("sources", array.toArrayList());
+    
+    result.success(map.toMap());
   }
 
   private void createLocalMediaStream(Result result) {


### PR DESCRIPTION
Fix for Android error:
Unable to getSources: Unsupported value: com.cloudwebrtc.webrtc.utils.ConstraintsArray@13ceca6#0