### PR TITLE
Updated rtc_dtmf_sender

### DIFF
--- a/example/lib/src/loopback_sample.dart
+++ b/example/lib/src/loopback_sample.dart
@@ -179,7 +179,7 @@ class _MyAppState extends State<LoopBackSample> {
   void _sendDtmf() async {
     var dtmfSender =
         _peerConnection.createDtmfSender(_localStream.getAudioTracks()[0]);
-    await dtmfSender.sendDtmf('123#');
+    await dtmfSender.insertDTMF('123#');
   }
 
   @override

--- a/lib/src/rtc_dtmf_sender.dart
+++ b/lib/src/rtc_dtmf_sender.dart
@@ -18,7 +18,7 @@ class RTCDTMFSender {
   ///          The browser will enforce a minimum value of 30 ms (that is,
   ///          if you specify a lower value, 30 ms will be used instead);
   ///          the default is 70 ms.
-  Future<void> sendDtmf(String tones,
+  Future<void> insertDTMF(String tones,
       {int duration = 100, int interToneGap = 70}) async {
     await _channel.invokeMethod('sendDtmf', <String, dynamic>{
       'peerConnectionId': _peerConnectionId,


### PR DESCRIPTION
The api call is name insertDTMF
https://developer.mozilla.org/en-US/docs/Web/API/RTCDTMFSender/insertDTMF
renamed to function call to match with the WebRTC Api.