### PR TITLE
[Android] Fixed `Track is null` 'Sender is null' issues when removing track.

### DIFF
--- a/android/src/main/java/com/cloudwebrtc/webrtc/PeerConnectionObserver.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/PeerConnectionObserver.java
@@ -163,7 +163,7 @@ class PeerConnectionObserver implements PeerConnection.Observer, EventChannel.St
     RtpSender getRtpSenderById(String id) {
         List<RtpSender> senders = peerConnection.getSenders();
         for(RtpSender sender : senders) {
-            if (id == sender.id()){
+            if (id.equals(sender.id())){
                 return sender;
             }
         }
@@ -777,7 +777,7 @@ class PeerConnectionObserver implements PeerConnection.Observer, EventChannel.St
   private Map<String, Object> mediaTrackToMap(MediaStreamTrack track){
       ConstraintsMap info = new ConstraintsMap();
       if(track != null){
-          info.putString("trackId", track.id());
+          info.putString("id", track.id());
           info.putString("label",track.getClass() == VideoTrack.class? "video": "audio");
           info.putString("kind",track.kind());
           info.putBoolean("enabled", track.enabled());


### PR DESCRIPTION
This pull request fixes the following issues:
In unified-plan when calling `mediaStream.removeTrack(sender.track)` it throws track is null error because the track id is null as in the Java code it is called `trackId` while in Dart code it anticipates `id`.
And also in `peerConnection.removeTrack(sender)` it throws sender is null issue because in the java code the track id is compared with the `==` operator which compares reference instead of equality, it is replaced with the `.equals()` method to fix this issue.
I have created the issue here https://github.com/flutter-webrtc/flutter-webrtc/issues/400