### PR TITLE
[iOS] fix removeTrack methodChannel response, onTrack's `stream` and `track` not being registered in native.

### DIFF
--- a/common/darwin/Classes/FlutterRTCPeerConnection.m
+++ b/common/darwin/Classes/FlutterRTCPeerConnection.m
@@ -545,7 +545,10 @@ didStartReceivingOnTransceiver:(RTCRtpTransceiver *)transceiver {
                 }
             }
         }
-        
+
+        peerConnection.remoteTracks[rtpReceiver.track.trackId] = rtpReceiver.track;
+        peerConnection.remoteStreams[mediaStreams[0].streamId] = mediaStreams[0];
+      
         eventSink(event);
     }
 }

--- a/common/darwin/Classes/FlutterWebRTCPlugin.m
+++ b/common/darwin/Classes/FlutterWebRTCPlugin.m
@@ -680,8 +680,7 @@
             details:nil]);
             return;
         }
-        [peerConnection removeTrack:sender];
-        result(nil);
+        result(@{@"result": @([peerConnection removeTrack:sender])});
     } else if ([@"addTransceiver" isEqualToString:call.method]){
         NSDictionary* argsMap = call.arguments;
         NSString* peerConnectionId = argsMap[@"peerConnectionId"];


### PR DESCRIPTION
This pull request is for two issues:
1. The `removeTrack`method in `rtc_peerconnection_impl.dart` anticipates a boolean in `Map` with `result` as a key
```dart
	bool result = response['result'];
```

&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; but the `removeTrack` in Darwin's sends `nil` which throws `The Method '[ ]' was called on null "result"` in Dart.

2. The second issue was not registering `stream` and `track` in `onTrack` for `PeerConnection` - `didAddReceiver` in `Obj-c` - which results into a `Not found video track for RTCMediaStream: {streamId}` error.

______________________
Related issues: 
1. https://github.com/flutter-webrtc/flutter-webrtc/issues/402
2. https://github.com/flutter-webrtc/flutter-webrtc/issues/403