### PR TITLE
[Darwin/Android] `RtpSender` `setParameters` functionality.

### DIFF
--- a/android/src/main/java/com/cloudwebrtc/webrtc/PeerConnectionObserver.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/PeerConnectionObserver.java
@@ -697,28 +697,6 @@ class PeerConnectionObserver implements PeerConnection.Observer, EventChannel.St
       }
     }
 
-    List<Map<String, Object>> codecs = (List<Map<String, Object>>)  newParameters.get("codecs");
-    final Iterator codecsIterator = codecs.iterator();
-    final Iterator nativeCodecsIterator = parameters.codecs.iterator();
-    while(codecsIterator.hasNext() && nativeCodecsIterator.hasNext()){
-      final RtpParameters.Codec nativeCodec = (RtpParameters.Codec) nativeCodecsIterator.next();
-      final Map<String, Object> codec = (Map<String, Object>) codecsIterator.next();
-      if(codec.containsKey("name")) {
-        nativeCodec.name = (String) codec.get("name");
-      }
-      if(codec.containsKey("payloadType")){
-        nativeCodec.payloadType  = (int) codec.get("payloadType");
-      }
-      if(codec.containsKey("clockRate")){
-        nativeCodec.clockRate  = (Integer) codec.get("clockRate");
-      }
-      if (codec.containsKey("numChannels")) {
-          nativeCodec.numChannels = (Integer) codec.get("numChannels");
-      }
-      if(codec.containsKey("parameters")){
-        nativeCodec.parameters =  (Map<String, String>) codec.get("parameters");
-      }
-    }
 
     return parameters;
   }

--- a/android/src/main/java/com/cloudwebrtc/webrtc/PeerConnectionObserver.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/PeerConnectionObserver.java
@@ -670,9 +670,57 @@ class PeerConnectionObserver implements PeerConnection.Observer, EventChannel.St
       return  init;
   }
 
-  private RtpParameters MapToRtpParameters(Map<String, Object> parameters) {
-      RtpParameters rtpParameters = null;
-      return rtpParameters;
+  private RtpParameters updateRtpParameters(Map<String, Object> newParameters, RtpParameters parameters){
+    List<Map<String, Object>> encodings = (List<Map<String, Object>>) newParameters.get("encodings");
+    final Iterator encodingsIterator = encodings.iterator();
+    final Iterator nativeEncodingsIterator = parameters.encodings.iterator();
+    while(encodingsIterator.hasNext() && nativeEncodingsIterator.hasNext()){
+      final RtpParameters.Encoding nativeEncoding = (RtpParameters.Encoding) nativeEncodingsIterator.next();
+      final Map<String, Object> encoding = (Map<String, Object>) encodingsIterator.next();
+      if(encoding.containsKey("active")){
+        nativeEncoding.active =  (Boolean) encoding.get("active");
+      }
+      if (encoding.containsKey("maxBitrateBps")) {
+          nativeEncoding.maxBitrateBps = (Integer) encoding.get("maxBitrateBps");
+      }
+      if (encoding.containsKey("minBitrateBps")) {
+        nativeEncoding.minBitrateBps = (Integer) encoding.get("minBitrateBps");
+      }
+      if (encoding.containsKey("maxFramerate")) {
+        nativeEncoding.maxFramerate = (Integer) encoding.get("maxFramerate");
+      }
+      if (encoding.containsKey("numTemporalLayers")) {
+        nativeEncoding.numTemporalLayers = (Integer) encoding.get("numTemporalLayers");
+      }
+      if (encoding.containsKey("scaleResolutionDownBy") ) {
+        nativeEncoding.scaleResolutionDownBy = (Double) encoding.get("scaleResolutionDownBy");
+      }
+    }
+
+    List<Map<String, Object>> codecs = (List<Map<String, Object>>)  newParameters.get("codecs");
+    final Iterator codecsIterator = codecs.iterator();
+    final Iterator nativeCodecsIterator = parameters.codecs.iterator();
+    while(codecsIterator.hasNext() && nativeCodecsIterator.hasNext()){
+      final RtpParameters.Codec nativeCodec = (RtpParameters.Codec) nativeCodecsIterator.next();
+      final Map<String, Object> codec = (Map<String, Object>) codecsIterator.next();
+      if(codec.containsKey("name")) {
+        nativeCodec.name = (String) codec.get("name");
+      }
+      if(codec.containsKey("payloadType")){
+        nativeCodec.payloadType  = (int) codec.get("payloadType");
+      }
+      if(codec.containsKey("clockRate")){
+        nativeCodec.clockRate  = (Integer) codec.get("clockRate");
+      }
+      if (codec.containsKey("numChannels")) {
+          nativeCodec.numChannels = (Integer) codec.get("numChannels");
+      }
+      if(codec.containsKey("parameters")){
+        nativeCodec.parameters =  (Map<String, String>) codec.get("parameters");
+      }
+    }
+
+    return parameters;
   }
 
   private Map<String, Object> rtpParametersToMap(RtpParameters rtpParameters){
@@ -919,8 +967,11 @@ class PeerConnectionObserver implements PeerConnection.Observer, EventChannel.St
             resultError("rtpSenderSetParameters", "sender is null", result);
             return;
         }
-        sender.setParameters(MapToRtpParameters(parameters));
-        result.success(null);
+        final RtpParameters updatedParameters = updateRtpParameters(parameters, sender.getParameters());
+        final Boolean success = sender.setParameters(updatedParameters);
+        ConstraintsMap params = new ConstraintsMap();
+        params.putBoolean("result", success);
+        result.success(params.toMap());
     }
 
     public void rtpSenderSetTrack(String rtpSenderId, MediaStreamTrack track, Result result, boolean replace) {

--- a/common/darwin/Classes/FlutterWebRTCPlugin.m
+++ b/common/darwin/Classes/FlutterWebRTCPlugin.m
@@ -271,7 +271,7 @@
             NSOperationQueue *queue = [[NSOperationQueue alloc] init];
             [queue addOperationWithBlock:^{
                 double durationMs = duration / 1000.0;
-		        double interToneGapMs = interToneGap / 1000.0;
+                double interToneGapMs = interToneGap / 1000.0;
                 [audioSender.dtmfSender insertDtmf :(NSString *)tone
                 duration:(NSTimeInterval) durationMs interToneGap:(NSTimeInterval)interToneGapMs];
                 NSLog(@"DTMF Tone played ");
@@ -624,7 +624,7 @@
             details:nil]);
             return;
         }
-        RTCRtpSender *sender = [self getRtpSnderById:peerConnection Id:senderId];
+        RTCRtpSender *sender = [self getRtpSenderById:peerConnection Id:senderId];
         if(sender == nil) {
             result([FlutterError errorWithCode:[NSString stringWithFormat:@"%@Failed",call.method]
             message:[NSString stringWithFormat:@"Error: sender not found!"]
@@ -673,7 +673,7 @@
             details:nil]);
             return;
         }
-        RTCRtpSender *sender = [self getRtpSnderById:peerConnection Id:senderId];
+        RTCRtpSender *sender = [self getRtpSenderById:peerConnection Id:senderId];
         if(sender == nil) {
             result([FlutterError errorWithCode:[NSString stringWithFormat:@"%@Failed",call.method]
             message:[NSString stringWithFormat:@"Error: sender not found!"]
@@ -798,7 +798,7 @@
     } else if ([@"rtpSenderSetParameters" isEqualToString:call.method]){
         NSDictionary* argsMap = call.arguments;
         NSString* peerConnectionId = argsMap[@"peerConnectionId"];
-        NSString* senderId = argsMap[@"senderId"];
+        NSString* senderId = argsMap[@"rtpSenderId"];
         NSDictionary* parameters = argsMap[@"parameters"];
         RTCPeerConnection *peerConnection = self.peerConnections[peerConnectionId];
         if(peerConnection == nil) {
@@ -807,16 +807,16 @@
             details:nil]);
             return;
         }
-        RTCRtpSender *sender = [self getRtpSnderById:peerConnection Id:senderId];
+        RTCRtpSender *sender = [self getRtpSenderById:peerConnection Id:senderId];
         if(sender == nil) {
             result([FlutterError errorWithCode:[NSString stringWithFormat:@"%@Failed",call.method]
             message:[NSString stringWithFormat:@"Error: sender not found!"]
             details:nil]);
             return;
         }
-        [sender setParameters:[self mapToRtpParameters:parameters]];
+        [sender setParameters:[self updateRtpParameters: parameters : sender.parameters]];
         
-        result(nil);
+        result(@{@"result": @(YES)});
     } else if ([@"rtpSenderReplaceTrack" isEqualToString:call.method]){
         NSDictionary* argsMap = call.arguments;
         NSString* peerConnectionId = argsMap[@"peerConnectionId"];
@@ -829,7 +829,7 @@
             details:nil]);
             return;
         }
-        RTCRtpSender *sender = [self getRtpSnderById:peerConnection Id:senderId];
+        RTCRtpSender *sender = [self getRtpSenderById:peerConnection Id:senderId];
         if(sender == nil) {
             result([FlutterError errorWithCode:[NSString stringWithFormat:@"%@Failed",call.method]
             message:[NSString stringWithFormat:@"Error: sender not found!"]
@@ -857,7 +857,7 @@
             details:nil]);
             return;
         }
-        RTCRtpSender *sender = [self getRtpSnderById:peerConnection Id:senderId];
+        RTCRtpSender *sender = [self getRtpSenderById:peerConnection Id:senderId];
         if(sender == nil) {
             result([FlutterError errorWithCode:[NSString stringWithFormat:@"%@Failed",call.method]
             message:[NSString stringWithFormat:@"Error: sender not found!"]
@@ -884,7 +884,7 @@
             details:nil]);
             return;
         }
-        RTCRtpSender *sender = [self getRtpSnderById:peerConnection Id:senderId];
+        RTCRtpSender *sender = [self getRtpSenderById:peerConnection Id:senderId];
         if(sender == nil) {
             result([FlutterError errorWithCode:[NSString stringWithFormat:@"%@Failed",call.method]
             message:[NSString stringWithFormat:@"Error: sender not found!"]
@@ -983,7 +983,7 @@
             }
         }
     }
-    return track;    
+    return track;
 }
 
 
@@ -1278,7 +1278,7 @@
     return nil;
 }
 
--(RTCRtpSender*) getRtpSnderById:(RTCPeerConnection *)peerConnection Id:(NSString*)Id {
+-(RTCRtpSender*) getRtpSenderById:(RTCPeerConnection *)peerConnection Id:(NSString*)Id {
    for( RTCRtpSender* sender in peerConnection.senders) {
        if([sender.senderId isEqualToString:Id]){
             return sender;
@@ -1376,10 +1376,34 @@
     return RTCRtpTransceiverDirectionInactive;
 }
 
--(RTCRtpParameters *)mapToRtpParameters:(NSDictionary *)map {
-    //TODO:
-    return nil;
-}
+-(RTCRtpParameters *)updateRtpParameters :(NSDictionary *)newParameters : (RTCRtpParameters *)parameters {
+    NSArray* encodings = [newParameters objectForKey:@"encodings"];
+    NSArray<RTCRtpEncodingParameters *> *nativeEncodings = parameters.encodings;
+    for(int i = 0; i < [nativeEncodings count]; i++){
+        RTCRtpEncodingParameters *nativeEncoding = [nativeEncodings objectAtIndex:i];
+        NSDictionary *encoding = [encodings objectAtIndex:i];
+        if([encoding objectForKey:@"active"]){
+            nativeEncoding.isActive =  [encoding objectForKey:@"active"];
+        }
+        if([encoding objectForKey:@"maxBitrateBps"]){
+            nativeEncoding.maxBitrateBps =  [encoding objectForKey:@"maxBitrateBps"];
+        }
+        if([encoding objectForKey:@"minBitrateBps"]){
+            nativeEncoding.minBitrateBps =  [encoding objectForKey:@"minBitrateBps"];
+        }
+        if([encoding objectForKey:@"maxFramerate"]){
+            nativeEncoding.maxFramerate =  [encoding objectForKey:@"maxFramerate"];
+        }
+        if([encoding objectForKey:@"numTemporalLayers"]){
+            nativeEncoding.isActive =  [encoding objectForKey:@"numTemporalLayers"];
+        }
+        if([encoding objectForKey:@"scaleResolutionDownBy"]){
+            nativeEncoding.scaleResolutionDownBy =  [encoding objectForKey:@"scaleResolutionDownBy"];
+        }
+    }
+
+    return parameters;
+  }
 
 -(NSString*)transceiverDirectionString:(RTCRtpTransceiverDirection)direction {
        switch (direction) {

--- a/lib/src/native/rtc_peerconnection_impl.dart
+++ b/lib/src/native/rtc_peerconnection_impl.dart
@@ -472,6 +472,7 @@ class RTCPeerConnectionNative extends RTCPeerConnection {
         'streamIds': streams.map((e) => e.id).toList()
       });
       var sender = RTCRtpSenderNative.fromMap(response);
+      sender.peerConnectionId = _peerConnectionId;
       _senders.add(sender);
       return sender;
     } on PlatformException catch (e) {


### PR DESCRIPTION
This pull request fixes the following issues:
In unified-plan when calling `RTCRtpSender.setParameters(parameters)` it throws `Unsupported value` error because the value being sent is `null` as in native code `mapToRtpParameters` returns `null`.
Creating `RtpParameters` from a map is not easy as there is no constructor for some of its properties, and setting the parameter is mainly targeted towards encodings.
So `mapToRtpParameters` is replaced with `updateRtpParameters` to update the values of the sender's parameters (encodings only as the rest is read-only) with the values sent from Dart through the method channel.

Related issue: https://github.com/flutter-webrtc/flutter-webrtc/issues/405