### PR TITLE
Unified plan gettracks

### DIFF
--- a/android/src/main/java/com/cloudwebrtc/webrtc/MethodCallHandlerImpl.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/MethodCallHandlerImpl.java
@@ -979,7 +979,6 @@ public class MethodCallHandlerImpl implements MethodCallHandler, StateProvider {
 
   MediaStream getStreamForId(String id, String peerConnectionId) {
     MediaStream stream = null;
-    Log.d(TAG, "££££££ getStreamForId: id: " + id + " peerConnectionId:" + peerConnectionId);
     if (peerConnectionId.length() > 0) {
       PeerConnectionObserver pco = mPeerConnectionObservers.get(peerConnectionId);
       if (pco != null) {

--- a/android/src/main/java/com/cloudwebrtc/webrtc/MethodCallHandlerImpl.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/MethodCallHandlerImpl.java
@@ -979,9 +979,12 @@ public class MethodCallHandlerImpl implements MethodCallHandler, StateProvider {
 
   MediaStream getStreamForId(String id, String peerConnectionId) {
     MediaStream stream = null;
+    Log.d(TAG, "££££££ getStreamForId: id: " + id + " peerConnectionId:" + peerConnectionId);
     if (peerConnectionId.length() > 0) {
       PeerConnectionObserver pco = mPeerConnectionObservers.get(peerConnectionId);
-      stream = pco.remoteStreams.get(id);
+      if (pco != null) {
+        stream = pco.remoteStreams.get(id);
+      }
     } else {
       for (Entry<String, PeerConnectionObserver> entry : mPeerConnectionObservers
               .entrySet()) {
@@ -1006,6 +1009,11 @@ public class MethodCallHandlerImpl implements MethodCallHandler, StateProvider {
       for (Entry<String, PeerConnectionObserver> entry : mPeerConnectionObservers.entrySet()) {
         PeerConnectionObserver pco = entry.getValue();
         track = pco.remoteTracks.get(trackId);
+
+        if (track == null) {
+          track = pco.getTransceiversTrack(trackId);
+        }
+
         if (track != null) {
           break;
         }
@@ -1128,8 +1136,8 @@ public class MethodCallHandlerImpl implements MethodCallHandler, StateProvider {
     }
   }
 
-  public void mediaStreamAddTrack(final String streaemId, final String trackId, Result result) {
-    MediaStream mediaStream = localStreams.get(streaemId);
+  public void mediaStreamAddTrack(final String streamId, final String trackId, Result result) {
+    MediaStream mediaStream = localStreams.get(streamId);
     if (mediaStream != null) {
       MediaStreamTrack track = getTrackForId(trackId);//localTracks.get(trackId);
       if (track != null) {
@@ -1139,16 +1147,16 @@ public class MethodCallHandlerImpl implements MethodCallHandler, StateProvider {
           mediaStream.addTrack((VideoTrack) track);
         }
       } else {
-        resultError("mediaStreamAddTrack", "mediaStreamAddTrack() tracking [" + trackId + "] is null", result);
+        resultError("mediaStreamAddTrack", "mediaStreamAddTrack() track [" + trackId + "] is null", result);
       }
     } else {
-      resultError("mediaStreamAddTrack", "mediaStreamAddTrack() streamId [" + streaemId + "] is null", result);
+      resultError("mediaStreamAddTrack", "mediaStreamAddTrack() stream [" + streamId + "] is null", result);
     }
     result.success(null);
   }
 
-  public void mediaStreamRemoveTrack(final String streaemId, final String trackId, Result result) {
-    MediaStream mediaStream = localStreams.get(streaemId);
+  public void mediaStreamRemoveTrack(final String streamId, final String trackId, Result result) {
+    MediaStream mediaStream = localStreams.get(streamId);
     if (mediaStream != null) {
       MediaStreamTrack track = localTracks.get(trackId);
       if (track != null) {
@@ -1161,7 +1169,7 @@ public class MethodCallHandlerImpl implements MethodCallHandler, StateProvider {
         resultError("mediaStreamRemoveTrack", "mediaStreamAddTrack() track [" + trackId + "] is null", result);
       }
     } else {
-      resultError("mediaStreamRemoveTrack", "mediaStreamAddTrack() track [" + trackId + "] is null", result);
+      resultError("mediaStreamRemoveTrack", "mediaStreamAddTrack() stream [" + streamId + "] is null", result);
     }
     result.success(null);
   }

--- a/android/src/main/java/com/cloudwebrtc/webrtc/PeerConnectionObserver.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/PeerConnectionObserver.java
@@ -997,4 +997,22 @@ class PeerConnectionObserver implements PeerConnection.Observer, EventChannel.St
       params.putArray("transceivers", transceiversParams.toArrayList());
       result.success(params.toMap());
     }
+
+    protected MediaStreamTrack getTransceiversTrack(String trackId) {
+        MediaStreamTrack track = null;
+        List<RtpTransceiver> transceivers = peerConnection.getTransceivers();
+        //Log.d(TAG, "££££££ getTrackForId: transceivers: " + transceivers.size());
+        for (RtpTransceiver transceiver : transceivers) {
+            RtpReceiver receiver = transceiver.getReceiver();
+            //Log.d(TAG, "££££££ getTrackForId: receiver is null: " + (receiver == null));
+            if (receiver != null) {
+                if (receiver.track() != null && receiver.track().id().equals(trackId)) {
+                    track = receiver.track();
+                    break;
+                }
+            }
+        }
+        return track;
+    }
+
 }

--- a/android/src/main/java/com/cloudwebrtc/webrtc/PeerConnectionObserver.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/PeerConnectionObserver.java
@@ -1001,12 +1001,13 @@ class PeerConnectionObserver implements PeerConnection.Observer, EventChannel.St
     protected MediaStreamTrack getTransceiversTrack(String trackId) {
         MediaStreamTrack track = null;
         List<RtpTransceiver> transceivers = peerConnection.getTransceivers();
-        //Log.d(TAG, "££££££ getTrackForId: transceivers: " + transceivers.size());
+        Log.d(TAG, "££££££ getTrackForId: transceivers: " + transceivers.size());
         for (RtpTransceiver transceiver : transceivers) {
             RtpReceiver receiver = transceiver.getReceiver();
-            //Log.d(TAG, "££££££ getTrackForId: receiver is null: " + (receiver == null));
+            Log.d(TAG, "££££££ getTrackForId: receiver is null: " + (receiver == null));
             if (receiver != null) {
                 if (receiver.track() != null && receiver.track().id().equals(trackId)) {
+                    Log.d(TAG, "££££££ found track " + trackId + "  is null: " + (receiver == null));
                     track = receiver.track();
                     break;
                 }

--- a/android/src/main/java/com/cloudwebrtc/webrtc/PeerConnectionObserver.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/PeerConnectionObserver.java
@@ -1001,13 +1001,10 @@ class PeerConnectionObserver implements PeerConnection.Observer, EventChannel.St
     protected MediaStreamTrack getTransceiversTrack(String trackId) {
         MediaStreamTrack track = null;
         List<RtpTransceiver> transceivers = peerConnection.getTransceivers();
-        Log.d(TAG, "££££££ getTrackForId: transceivers: " + transceivers.size());
         for (RtpTransceiver transceiver : transceivers) {
             RtpReceiver receiver = transceiver.getReceiver();
-            Log.d(TAG, "££££££ getTrackForId: receiver is null: " + (receiver == null));
             if (receiver != null) {
                 if (receiver.track() != null && receiver.track().id().equals(trackId)) {
-                    Log.d(TAG, "££££££ found track " + trackId + "  is null: " + (receiver == null));
                     track = receiver.track();
                     break;
                 }

--- a/common/darwin/Classes/FlutterRTCPeerConnection.m
+++ b/common/darwin/Classes/FlutterRTCPeerConnection.m
@@ -547,7 +547,9 @@ didStartReceivingOnTransceiver:(RTCRtpTransceiver *)transceiver {
         }
 
         peerConnection.remoteTracks[rtpReceiver.track.trackId] = rtpReceiver.track;
-        peerConnection.remoteStreams[mediaStreams[0].streamId] = mediaStreams[0];
+        if (mediaStreams.count > 0) {
+            peerConnection.remoteStreams[mediaStreams[0].streamId] = mediaStreams[0];
+        }
       
         eventSink(event);
     }

--- a/common/darwin/Classes/FlutterWebRTCPlugin.m
+++ b/common/darwin/Classes/FlutterWebRTCPlugin.m
@@ -994,7 +994,6 @@
     if (!track) {
         for (RTCPeerConnection *peerConnection in _peerConnections.allValues) {
             track = peerConnection.remoteTracks[trackId];
-            
             if (!track) {
                 for (RTCRtpTransceiver *transceiver in peerConnection.transceivers) {
                     if (transceiver.receiver.track != nil && [transceiver.receiver.track.trackId isEqual:trackId]) {
@@ -1003,7 +1002,6 @@
                     }
                 }
             }
-            
             if (track) {
                 break;
             }

--- a/common/darwin/Classes/FlutterWebRTCPlugin.m
+++ b/common/darwin/Classes/FlutterWebRTCPlugin.m
@@ -382,7 +382,7 @@
 
         RTCMediaStream *stream = self.localStreams[streamId];
         if (stream) {
-            RTCMediaStreamTrack *track = self.localTracks[trackId];
+            RTCMediaStreamTrack *track = [self trackForId: trackId];
             if(track != nil) {
                 if([track isKindOfClass:[RTCAudioTrack class]]) {
                     RTCAudioTrack *audioTrack = (RTCAudioTrack *)track;
@@ -994,6 +994,16 @@
     if (!track) {
         for (RTCPeerConnection *peerConnection in _peerConnections.allValues) {
             track = peerConnection.remoteTracks[trackId];
+            
+            if (!track) {
+                for (RTCRtpTransceiver *transceiver in peerConnection.transceivers) {
+                    if (transceiver.receiver.track != nil && [transceiver.receiver.track.trackId isEqual:trackId]) {
+                        track = transceiver.receiver.track;
+                        break;
+                    }
+                }
+            }
+            
             if (track) {
                 break;
             }


### PR DESCRIPTION
when the remote end is using stage 3 of the evolution of tracks (see https://blog.mozilla.org/webrtc/the-evolution-of-webrtc/) and using transceivers.  

`var t = pc.addTransceiver("video", { direction : 'inactive'});`

and then at a later time adding a track to the sender

```
t.direction = "sendonly";
t.sender.replaceTrack(track);
```

Streams are not used so I needed to add this code so as to be able to display the track in the video renderer.

I've had to make a local stream, add the track to it, which meant going and finding it in the transceiver.  Then the video renderer can take the new local stream and play the track.