### PR TITLE
Bluetooth switching enabled when switching `enableSpeakerphone`  value (if they are connected). #201

### DIFF
--- a/android/src/main/java/com/cloudwebrtc/webrtc/utils/RTCAudioManager.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/utils/RTCAudioManager.java
@@ -352,15 +352,15 @@ public class RTCAudioManager {
   public void setDefaultAudioDevice(AudioDevice defaultDevice) {
     ThreadUtils.checkIsOnMainThread();
     switch (defaultDevice) {
+      case EARPIECE:
+      if (hasEarpiece()) {
+        defaultAudioDevice = defaultDevice;
+      } else {
+        defaultAudioDevice = AudioDevice.SPEAKER_PHONE;
+      }
+      break;
       case SPEAKER_PHONE:
         defaultAudioDevice = defaultDevice;
-        break;
-      case EARPIECE:
-        if (hasEarpiece()) {
-          defaultAudioDevice = defaultDevice;
-        } else {
-          defaultAudioDevice = AudioDevice.SPEAKER_PHONE;
-        }
         break;
       default:
         Log.e(TAG, "Invalid default audio device selection");
@@ -404,9 +404,13 @@ public class RTCAudioManager {
 
   /** Sets the speaker phone mode. */
   public void setSpeakerphoneOn(boolean on) {
-    boolean wasOn = audioManager.isSpeakerphoneOn();
-    if (wasOn == on) {
-      return;
+    final RTCBluetoothManager.State btManagerState = bluetoothManager.getState();
+    final boolean isBTAvailable =  
+    btManagerState == RTCBluetoothManager.State.SCO_CONNECTED
+        || btManagerState == RTCBluetoothManager.State.SCO_CONNECTING
+        || btManagerState == RTCBluetoothManager.State.HEADSET_AVAILABLE;
+    if(!on && isBTAvailable){
+        bluetoothManager.startScoAudio();
     }
     audioManager.setSpeakerphoneOn(on);
   }

--- a/android/src/main/java/com/cloudwebrtc/webrtc/utils/RTCAudioManager.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/utils/RTCAudioManager.java
@@ -404,6 +404,10 @@ public class RTCAudioManager {
 
   /** Sets the speaker phone mode. */
   public void setSpeakerphoneOn(boolean on) {
+    boolean wasOn = audioManager.isSpeakerphoneOn();
+    if (wasOn == on) {
+      return;
+    }
     final RTCBluetoothManager.State btManagerState = bluetoothManager.getState();
     final boolean isBTAvailable =  
     btManagerState == RTCBluetoothManager.State.SCO_CONNECTED

--- a/android/src/main/java/com/cloudwebrtc/webrtc/utils/RTCBluetoothManager.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/utils/RTCBluetoothManager.java
@@ -324,6 +324,12 @@ public class RTCBluetoothManager {
       Log.e(TAG, "BT SCO connection fails - no more attempts");
       return false;
     }
+    List<BluetoothDevice> devices = bluetoothHeadset.getConnectedDevices();
+    if (!devices.isEmpty()) {
+      bluetoothDevice = devices.get(0);
+      bluetoothState = State.HEADSET_AVAILABLE;
+    } 
+    
     if (bluetoothState != State.HEADSET_AVAILABLE) {
       Log.e(TAG, "BT SCO connection fails - no headset available");
       return false;

--- a/common/darwin/Classes/FlutterWebRTCPlugin.m
+++ b/common/darwin/Classes/FlutterWebRTCPlugin.m
@@ -559,8 +559,10 @@
         _speakerOn = enable.boolValue;
         AVAudioSession *audioSession = [AVAudioSession sharedInstance];
         [audioSession setCategory:AVAudioSessionCategoryPlayAndRecord
-                      withOptions:_speakerOn ? AVAudioSessionCategoryOptionDefaultToSpeaker : 0
-                            error:nil];
+                      withOptions:_speakerOn ? AVAudioSessionCategoryOptionDefaultToSpeaker 
+                      : 
+                      AVAudioSessionCategoryOptionAllowBluetooth|AVAudioSessionCategoryOptionAllowBluetoothA2DP
+                        error:nil];
         [audioSession setActive:YES error:nil];
         result(nil);
 #else


### PR DESCRIPTION
This is a quick fix to enable Bluetooth switching on iOS and fix the issue where setting `enableSpeakerphone` to false would default to the phone (call) speaker even if a Bluetooth headset is connected.
This would fix the #201 issue, we aren't able to pick devices though.