### PR TITLE
Getting screen content can only be successful for the first time

### DIFF
--- a/android/src/main/java/com/cloudwebrtc/webrtc/GetUserMediaImpl.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/GetUserMediaImpl.java
@@ -471,7 +471,10 @@ class GetUserMediaImpl {
                                         new MediaProjection.Callback() {
                                             @Override
                                             public void onStop() {
-                                                resultError("MediaProjection.Callback()", "User revoked permission to capture the screen.", result);
+                                                super.onStop();
+                                                // After Huawei P30 and Android 10 version test, the onstop method is called, which will not affect the next process, 
+                                                // and there is no need to call the resulterror method
+                                                //resultError("MediaProjection.Callback()", "User revoked permission to capture the screen.", result);
                                             }
                                         });
                         if (videoCapturer == null) {


### PR DESCRIPTION
我看了下报错处的代码，并参照网上的代码做了修改，经过多次测试，没有再出现“getDisplayMedia只有第一次成功后面失败，报错user revoked permission”的问题。这个问题并不是稳定复现，但概率比较高。测试设备华为p30 android10，华为mate8 android 7。