### PR TITLE
Android端添加重新激活相机功能，重写 Web端RTCVideoView渲染功能

### DIFF
--- a/android/src/main/java/com/cloudwebrtc/webrtc/FlutterRTCVideoRenderer.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/FlutterRTCVideoRenderer.java
@@ -11,6 +11,7 @@ import java.util.List;
 
 import org.webrtc.EglBase;
 import org.webrtc.MediaStream;
+import org.webrtc.MediaStreamTrack;
 import org.webrtc.RendererCommon.RendererEvents;
 import org.webrtc.VideoTrack;
 
@@ -23,13 +24,14 @@ public class FlutterRTCVideoRenderer implements EventChannel.StreamHandler {
     private final SurfaceTexture texture;
     private TextureRegistry.SurfaceTextureEntry entry;
     private int id = -1;
+    private MediaStream mediaStream;
 
-    public void Dispose(){
+    public void Dispose() {
         //destroy
-        if(surfaceTextureRenderer != null) {
+        if (surfaceTextureRenderer != null) {
             surfaceTextureRenderer.release();
         }
-        if(eventChannel != null)
+        if (eventChannel != null)
             eventChannel.setStreamHandler(null);
 
         eventSink = null;
@@ -43,9 +45,9 @@ public class FlutterRTCVideoRenderer implements EventChannel.StreamHandler {
     private RendererEvents rendererEvents;
 
     private void listenRendererEvents() {
-    rendererEvents = new RendererEvents() {
+        rendererEvents = new RendererEvents() {
             private int _rotation = -1;
-            private  int _width = 0, _height = 0;
+            private int _width = 0, _height = 0;
 
             @Override
             public void onFirstFrameRendered() {
@@ -60,8 +62,8 @@ public class FlutterRTCVideoRenderer implements EventChannel.StreamHandler {
                     int videoWidth, int videoHeight,
                     int rotation) {
 
-                if(eventSink != null) {
-                    if(_width != videoWidth || _height != videoHeight) {
+                if (eventSink != null) {
+                    if (_width != videoWidth || _height != videoHeight) {
                         ConstraintsMap params = new ConstraintsMap();
                         params.putString("event", "didTextureChangeVideoSize");
                         params.putInt("id", id);
@@ -72,7 +74,7 @@ public class FlutterRTCVideoRenderer implements EventChannel.StreamHandler {
                         eventSink.success(params.toMap());
                     }
 
-                    if(_rotation != rotation) {
+                    if (_rotation != rotation) {
                         ConstraintsMap params2 = new ConstraintsMap();
                         params2.putString("event", "didTextureChangeRotation");
                         params2.putInt("id", id);
@@ -84,6 +86,7 @@ public class FlutterRTCVideoRenderer implements EventChannel.StreamHandler {
             }
         };
     }
+
     private SurfaceTextureRenderer surfaceTextureRenderer;
 
     /**
@@ -105,11 +108,11 @@ public class FlutterRTCVideoRenderer implements EventChannel.StreamHandler {
         this.entry = entry;
     }
 
-    public void setEventChannel(EventChannel eventChannel){
+    public void setEventChannel(EventChannel eventChannel) {
         this.eventChannel = eventChannel;
     }
 
-    public void setId(int id){
+    public void setId(int id) {
         this.id = id;
     }
 
@@ -137,11 +140,11 @@ public class FlutterRTCVideoRenderer implements EventChannel.StreamHandler {
      * specified {@code mediaStream}.
      *
      * @param mediaStream The {@code MediaStream} to be rendered by this
-     * {@code FlutterRTCVideoRenderer} or {@code null}.
+     *                    {@code FlutterRTCVideoRenderer} or {@code null}.
      */
     public void setStream(MediaStream mediaStream) {
         VideoTrack videoTrack;
-
+        this.mediaStream = mediaStream;
         if (mediaStream == null) {
             videoTrack = null;
         } else {
@@ -157,9 +160,9 @@ public class FlutterRTCVideoRenderer implements EventChannel.StreamHandler {
      * Sets the {@code VideoTrack} to be rendered by this {@code FlutterRTCVideoRenderer}.
      *
      * @param videoTrack The {@code VideoTrack} to be rendered by this
-     * {@code FlutterRTCVideoRenderer} or {@code null}.
+     *                   {@code FlutterRTCVideoRenderer} or {@code null}.
      */
-    private void setVideoTrack(VideoTrack videoTrack) {
+    public void setVideoTrack(VideoTrack videoTrack) {
         VideoTrack oldValue = this.videoTrack;
 
         if (oldValue != videoTrack) {
@@ -202,4 +205,17 @@ public class FlutterRTCVideoRenderer implements EventChannel.StreamHandler {
         }
     }
 
+    public boolean checkMediaStream(String id) {
+        if (null == id || null == mediaStream) {
+            return false;
+        }
+        return id.equals(mediaStream.getId());
+    }
+
+    public boolean checkVideoTrack(String id) {
+        if (null == id || null == videoTrack) {
+            return false;
+        }
+        return id.equals(videoTrack.id());
+    }
 }

--- a/android/src/main/java/com/cloudwebrtc/webrtc/FlutterWebRTCPlugin.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/FlutterWebRTCPlugin.java
@@ -1,18 +1,26 @@
 package com.cloudwebrtc.webrtc;
 
 import android.app.Activity;
+import android.app.Application;
 import android.content.Context;
+import android.os.Bundle;
 import android.util.Log;
 import androidx.annotation.NonNull;
+import androidx.lifecycle.DefaultLifecycleObserver;
+import androidx.lifecycle.Lifecycle;
+import androidx.lifecycle.LifecycleOwner;
 import com.cloudwebrtc.webrtc.MethodCallHandlerImpl.AudioManager;
 import com.cloudwebrtc.webrtc.utils.RTCAudioManager;
+import io.flutter.embedding.android.FlutterActivity;
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.embedding.engine.plugins.activity.ActivityAware;
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding;
+import io.flutter.embedding.engine.plugins.lifecycle.HiddenLifecycleReference;
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.PluginRegistry.Registrar;
 import io.flutter.view.TextureRegistry;
+
 import java.util.Set;
 
 /**
@@ -20,123 +28,181 @@ import java.util.Set;
  */
 public class FlutterWebRTCPlugin implements FlutterPlugin, ActivityAware {
 
-  static public final String TAG = "FlutterWebRTCPlugin";
+    static public final String TAG = "FlutterWebRTCPlugin";
+    private static Application application;
 
-  private RTCAudioManager rtcAudioManager;
-  private MethodChannel channel;
-  private MethodCallHandlerImpl methodCallHandler;
+    private RTCAudioManager rtcAudioManager;
+    private MethodChannel channel;
+    private MethodCallHandlerImpl methodCallHandler;
+    private LifeCycleObserver observer;
+    private Lifecycle lifecycle;
 
-  public FlutterWebRTCPlugin() {
-  }
-
-  /**
-   * Plugin registration.
-   */
-  public static void registerWith(Registrar registrar) {
-    final FlutterWebRTCPlugin plugin = new FlutterWebRTCPlugin();
-
-    plugin.startListening(registrar.context(), registrar.messenger(), registrar.textures());
-
-    if (registrar.activeContext() instanceof Activity) {
-      plugin.methodCallHandler.setActivity((Activity) registrar.activeContext());
+    public FlutterWebRTCPlugin() {
     }
 
-    registrar.addViewDestroyListener(view -> {
-      plugin.stopListening();
-      return false;
-    });
-  }
+    /**
+     * Plugin registration.
+     */
+    public static void registerWith(Registrar registrar) {
+        final FlutterWebRTCPlugin plugin = new FlutterWebRTCPlugin();
 
-  @Override
-  public void onAttachedToEngine(@NonNull FlutterPluginBinding binding) {
-    startListening(binding.getApplicationContext(), binding.getBinaryMessenger(),
-        binding.getTextureRegistry());
-  }
+        plugin.startListening(registrar.context(), registrar.messenger(), registrar.textures());
 
-  @Override
-  public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
-    stopListening();
-  }
+        if (registrar.activeContext() instanceof Activity) {
+            plugin.methodCallHandler.setActivity((Activity) registrar.activeContext());
+        }
+        application = ((Application) registrar.context().getApplicationContext());
+        application.registerActivityLifecycleCallbacks(plugin.observer);
 
-  @Override
-  public void onAttachedToActivity(@NonNull ActivityPluginBinding binding) {
-    methodCallHandler.setActivity(binding.getActivity());
-  }
-
-  @Override
-  public void onDetachedFromActivityForConfigChanges() {
-    methodCallHandler.setActivity(null);
-  }
-
-  @Override
-  public void onReattachedToActivityForConfigChanges(@NonNull ActivityPluginBinding binding) {
-    methodCallHandler.setActivity(binding.getActivity());
-  }
-
-  @Override
-  public void onDetachedFromActivity() {
-    methodCallHandler.setActivity(null);
-  }
-
-  private void startListening(final Context context, BinaryMessenger messenger,
-      TextureRegistry textureRegistry) {
-    methodCallHandler = new MethodCallHandlerImpl(context, messenger, textureRegistry,
-        new AudioManager() {
-          @Override
-          public void onAudioManagerRequested(boolean requested) {
-            if (requested) {
-              if (rtcAudioManager == null) {
-                rtcAudioManager = RTCAudioManager.create(context);
-              }
-              rtcAudioManager.start(FlutterWebRTCPlugin.this::onAudioManagerDevicesChanged);
-            } else {
-              if (rtcAudioManager != null) {
-                rtcAudioManager.stop();
-                rtcAudioManager = null;
-              }
-            }
-          }
-
-          @Override
-          public void setMicrophoneMute(boolean mute) {
-            if (rtcAudioManager != null) {
-              rtcAudioManager.setMicrophoneMute(mute);
-            }
-          }
-
-          @Override
-          public void setSpeakerphoneOn(boolean on) {
-            if (rtcAudioManager != null) {
-              rtcAudioManager.setSpeakerphoneOn(on);
-            }
-          }
+        registrar.addViewDestroyListener(view -> {
+            plugin.stopListening();
+            return false;
         });
-
-    channel = new MethodChannel(messenger, "FlutterWebRTC.Method");
-    channel.setMethodCallHandler(methodCallHandler);
-  }
-
-  private void stopListening() {
-    methodCallHandler.dispose();
-    methodCallHandler = null;
-    channel.setMethodCallHandler(null);
-
-    if (rtcAudioManager != null) {
-      Log.d(TAG, "Stopping the audio manager...");
-      rtcAudioManager.stop();
-      rtcAudioManager = null;
     }
-  }
 
-  // This method is called when the audio manager reports audio device change,
-  // e.g. from wired headset to speakerphone.
-  private void onAudioManagerDevicesChanged(
-      final RTCAudioManager.AudioDevice device,
-      final Set<RTCAudioManager.AudioDevice> availableDevices) {
-    Log.d(TAG, "onAudioManagerDevicesChanged: " + availableDevices + ", "
-        + "selected: " + device);
-    // TODO(henrika): add callback handler.
-  }
+    @Override
+    public void onAttachedToEngine(@NonNull FlutterPluginBinding binding) {
+        startListening(binding.getApplicationContext(), binding.getBinaryMessenger(),
+                binding.getTextureRegistry());
+    }
 
+    @Override
+    public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
+        stopListening();
+    }
 
+    @Override
+    public void onAttachedToActivity(@NonNull ActivityPluginBinding binding) {
+        methodCallHandler.setActivity(binding.getActivity());
+        this.observer = new LifeCycleObserver();
+        this.lifecycle = ((HiddenLifecycleReference) binding.getLifecycle()).getLifecycle();
+        this.lifecycle.addObserver(this.observer);
+    }
+
+    @Override
+    public void onDetachedFromActivityForConfigChanges() {
+        methodCallHandler.setActivity(null);
+    }
+
+    @Override
+    public void onReattachedToActivityForConfigChanges(@NonNull ActivityPluginBinding binding) {
+        methodCallHandler.setActivity(binding.getActivity());
+    }
+
+    @Override
+    public void onDetachedFromActivity() {
+        methodCallHandler.setActivity(null);
+        if (this.observer != null) {
+            this.lifecycle.removeObserver(this.observer);
+            this.application.unregisterActivityLifecycleCallbacks(this.observer);
+        }
+        this.lifecycle = null;
+    }
+
+    private void startListening(final Context context, BinaryMessenger messenger,
+                                TextureRegistry textureRegistry) {
+        methodCallHandler = new MethodCallHandlerImpl(context, messenger, textureRegistry,
+                new AudioManager() {
+                    @Override
+                    public void onAudioManagerRequested(boolean requested) {
+                        if (requested) {
+                            if (rtcAudioManager == null) {
+                                rtcAudioManager = RTCAudioManager.create(context);
+                            }
+                            rtcAudioManager.start(FlutterWebRTCPlugin.this::onAudioManagerDevicesChanged);
+                        } else {
+                            if (rtcAudioManager != null) {
+                                rtcAudioManager.stop();
+                                rtcAudioManager = null;
+                            }
+                        }
+                    }
+
+                    @Override
+                    public void setMicrophoneMute(boolean mute) {
+                        if (rtcAudioManager != null) {
+                            rtcAudioManager.setMicrophoneMute(mute);
+                        }
+                    }
+
+                    @Override
+                    public void setSpeakerphoneOn(boolean on) {
+                        if (rtcAudioManager != null) {
+                            rtcAudioManager.setSpeakerphoneOn(on);
+                        }
+                    }
+                });
+
+        channel = new MethodChannel(messenger, "FlutterWebRTC.Method");
+        channel.setMethodCallHandler(methodCallHandler);
+    }
+
+    private void stopListening() {
+        methodCallHandler.dispose();
+        methodCallHandler = null;
+        channel.setMethodCallHandler(null);
+
+        if (rtcAudioManager != null) {
+            Log.d(TAG, "Stopping the audio manager...");
+            rtcAudioManager.stop();
+            rtcAudioManager = null;
+        }
+    }
+
+    // This method is called when the audio manager reports audio device change,
+    // e.g. from wired headset to speakerphone.
+    private void onAudioManagerDevicesChanged(
+            final RTCAudioManager.AudioDevice device,
+            final Set<RTCAudioManager.AudioDevice> availableDevices) {
+        Log.d(TAG, "onAudioManagerDevicesChanged: " + availableDevices + ", "
+                + "selected: " + device);
+        // TODO(henrika): add callback handler.
+    }
+
+    private class LifeCycleObserver implements Application.ActivityLifecycleCallbacks, DefaultLifecycleObserver {
+
+        @Override
+        public void onActivityCreated(Activity activity, Bundle savedInstanceState) {
+
+        }
+
+        @Override
+        public void onActivityStarted(Activity activity) {
+
+        }
+
+        @Override
+        public void onActivityResumed(Activity activity) {
+            if (null != methodCallHandler) {
+                methodCallHandler.reStartCamera();
+            }
+        }
+
+        @Override
+        public void onResume(LifecycleOwner owner) {
+            if (null != methodCallHandler) {
+                methodCallHandler.reStartCamera();
+            }
+        }
+
+        @Override
+        public void onActivityPaused(Activity activity) {
+
+        }
+
+        @Override
+        public void onActivityStopped(Activity activity) {
+
+        }
+
+        @Override
+        public void onActivitySaveInstanceState(Activity activity, Bundle outState) {
+
+        }
+
+        @Override
+        public void onActivityDestroyed(Activity activity) {
+
+        }
+    }
 }

--- a/android/src/main/java/com/cloudwebrtc/webrtc/MethodCallHandlerImpl.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/MethodCallHandlerImpl.java
@@ -74,1565 +74,1593 @@ import io.flutter.view.TextureRegistry.SurfaceTextureEntry;
 import static com.cloudwebrtc.webrtc.utils.MediaConstraintsUtils.parseMediaConstraints;
 
 public class MethodCallHandlerImpl implements MethodCallHandler, StateProvider {
+    interface AudioManager {
+
+        void onAudioManagerRequested(boolean requested);
+
+        void setMicrophoneMute(boolean mute);
+
+        void setSpeakerphoneOn(boolean on);
 
 
-  interface AudioManager {
-
-    void onAudioManagerRequested(boolean requested);
-
-    void setMicrophoneMute(boolean mute);
-
-    void setSpeakerphoneOn(boolean on);
-
-
-  }
-
-  static public final String TAG = "FlutterWebRTCPlugin";
-
-  private final Map<String, PeerConnectionObserver> mPeerConnectionObservers = new HashMap<>();
-  private BinaryMessenger messenger;
-  private Context context;
-  private final TextureRegistry textures;
-
-  private PeerConnectionFactory mFactory;
-
-  private final Map<String, MediaStream> localStreams = new HashMap<>();
-  private final Map<String, MediaStreamTrack> localTracks = new HashMap<>();
-
-  private LongSparseArray<FlutterRTCVideoRenderer> renders = new LongSparseArray<>();
-
-  /**
-   * The implementation of {@code getUserMedia} extracted into a separate file in order to reduce
-   * complexity and to (somewhat) separate concerns.
-   */
-  private GetUserMediaImpl getUserMediaImpl;
-
-  private final AudioManager audioManager;
-
-  private AudioDeviceModule audioDeviceModule;
-
-  private Activity activity;
-
-  MethodCallHandlerImpl(Context context, BinaryMessenger messenger, TextureRegistry textureRegistry,
-      @NonNull AudioManager audioManager) {
-    this.context = context;
-    this.textures = textureRegistry;
-    this.messenger = messenger;
-    this.audioManager = audioManager;
-  }
-
-  static private void resultError(String method, String error, Result result) {
-    String errorMsg = method + "(): " + error;
-    result.error(method, errorMsg,null);
-    Log.d(TAG, errorMsg);
-  }
-
-  void dispose() {
-    mPeerConnectionObservers.clear();
-  }
-
-  private void ensureInitialized() {
-    if (mFactory != null) {
-      return;
     }
 
-    PeerConnectionFactory.initialize(
-        InitializationOptions.builder(context)
-            .setEnableInternalTracer(true)
-            .createInitializationOptions());
+    static public final String TAG = "FlutterWebRTCPlugin";
 
-    // Initialize EGL contexts required for HW acceleration.
-    EglBase.Context eglContext = EglUtils.getRootEglBaseContext();
+    private final Map<String, PeerConnectionObserver> mPeerConnectionObservers = new HashMap<>();
+    private BinaryMessenger messenger;
+    private Context context;
+    private final TextureRegistry textures;
 
-    getUserMediaImpl = new GetUserMediaImpl(this, context);
+    private PeerConnectionFactory mFactory;
 
-    audioDeviceModule = JavaAudioDeviceModule.builder(context)
-        .setUseHardwareAcousticEchoCanceler(true)
-        .setUseHardwareNoiseSuppressor(true)
-        .setSamplesReadyCallback(getUserMediaImpl.inputSamplesInterceptor)
-        .createAudioDeviceModule();
+    private final Map<String, MediaStream> localStreams = new HashMap<>();
+    private final Map<String, MediaStreamTrack> localTracks = new HashMap<>();
 
-    getUserMediaImpl.audioDeviceModule = (JavaAudioDeviceModule) audioDeviceModule;
+    private LongSparseArray<FlutterRTCVideoRenderer> renders = new LongSparseArray<>();
 
-    mFactory = PeerConnectionFactory.builder()
-        .setOptions(new Options())
-        .setVideoEncoderFactory(new DefaultVideoEncoderFactory(eglContext, false, true))
-        .setVideoDecoderFactory(new DefaultVideoDecoderFactory(eglContext))
-        .setAudioDeviceModule(audioDeviceModule)
-        .createPeerConnectionFactory();
-  }
+    /**
+     * The implementation of {@code getUserMedia} extracted into a separate file in order to reduce
+     * complexity and to (somewhat) separate concerns.
+     */
+    private GetUserMediaImpl getUserMediaImpl;
 
-  @Override
-  public void onMethodCall(MethodCall call, @NonNull Result notSafeResult) {
-    ensureInitialized();
+    private final AudioManager audioManager;
 
-    final AnyThreadResult result = new AnyThreadResult(notSafeResult);
-    switch (call.method) {
-      case "createPeerConnection": {
-        Map<String, Object> constraints = call.argument("constraints");
-        Map<String, Object> configuration = call.argument("configuration");
-        String peerConnectionId = peerConnectionInit(new ConstraintsMap(configuration),
-            new ConstraintsMap((constraints)));
-        ConstraintsMap res = new ConstraintsMap();
-        res.putString("peerConnectionId", peerConnectionId);
-        result.success(res.toMap());
-        break;
-      }
-      case "getUserMedia": {
-        Map<String, Object> constraints = call.argument("constraints");
-        ConstraintsMap constraintsMap = new ConstraintsMap(constraints);
-        getUserMedia(constraintsMap, result);
-        break;
-      }
-      case "createLocalMediaStream":
-        createLocalMediaStream(result);
-        break;
-      case "getSources":
-        getSources(result);
-        break;
-      case "createOffer": {
-        String peerConnectionId = call.argument("peerConnectionId");
-        Map<String, Object> constraints = call.argument("constraints");
-        peerConnectionCreateOffer(peerConnectionId, new ConstraintsMap(constraints), result);
-        break;
-      }
-      case "createAnswer": {
-        String peerConnectionId = call.argument("peerConnectionId");
-        Map<String, Object> constraints = call.argument("constraints");
-        peerConnectionCreateAnswer(peerConnectionId, new ConstraintsMap(constraints), result);
-        break;
-      }
-      case "mediaStreamGetTracks": {
-        String streamId = call.argument("streamId");
-        MediaStream stream = getStreamForId(streamId, "");
-        Map<String, Object> resultMap = new HashMap<>();
-        List<Object> audioTracks = new ArrayList<>();
-        List<Object> videoTracks = new ArrayList<>();
-        for (AudioTrack track : stream.audioTracks) {
-          localTracks.put(track.id(), track);
-          Map<String, Object> trackMap = new HashMap<>();
-          trackMap.put("enabled", track.enabled());
-          trackMap.put("id", track.id());
-          trackMap.put("kind", track.kind());
-          trackMap.put("label", track.id());
-          trackMap.put("readyState", "live");
-          trackMap.put("remote", false);
-          audioTracks.add(trackMap);
-        }
-        for (VideoTrack track : stream.videoTracks) {
-          localTracks.put(track.id(), track);
-          Map<String, Object> trackMap = new HashMap<>();
-          trackMap.put("enabled", track.enabled());
-          trackMap.put("id", track.id());
-          trackMap.put("kind", track.kind());
-          trackMap.put("label", track.id());
-          trackMap.put("readyState", "live");
-          trackMap.put("remote", false);
-          videoTracks.add(trackMap);
-        }
-        resultMap.put("audioTracks", audioTracks);
-        resultMap.put("videoTracks", videoTracks);
-        result.success(resultMap);
-        break;
-      }
-      case "addStream": {
-        String streamId = call.argument("streamId");
-        String peerConnectionId = call.argument("peerConnectionId");
-        peerConnectionAddStream(streamId, peerConnectionId, result);
-        break;
-      }
-      case "removeStream": {
-        String streamId = call.argument("streamId");
-        String peerConnectionId = call.argument("peerConnectionId");
-        peerConnectionRemoveStream(streamId, peerConnectionId, result);
-        break;
-      }
-      case "setLocalDescription": {
-        String peerConnectionId = call.argument("peerConnectionId");
-        Map<String, Object> description = call.argument("description");
-        peerConnectionSetLocalDescription(new ConstraintsMap(description), peerConnectionId,
-            result);
-        break;
-      }
-      case "setRemoteDescription": {
-        String peerConnectionId = call.argument("peerConnectionId");
-        Map<String, Object> description = call.argument("description");
-        peerConnectionSetRemoteDescription(new ConstraintsMap(description), peerConnectionId,
-            result);
-        break;
-      }
-      case "sendDtmf": {
-        String peerConnectionId = call.argument("peerConnectionId");
-        String tone = call.argument("tone");
-        int duration = call.argument("duration");
-        int gap = call.argument("gap");
-        PeerConnection peerConnection = getPeerConnection(peerConnectionId);
-        if (peerConnection != null) {
-          RtpSender audioSender = null;
-          for (RtpSender sender : peerConnection.getSenders()) {
+    private AudioDeviceModule audioDeviceModule;
 
-            if (sender.track().kind().equals("audio")) {
-             audioSender = sender;
-            } 
-          }
-          if (audioSender != null) {
-            DtmfSender dtmfSender = audioSender.dtmf();
-            dtmfSender.insertDtmf(tone, duration, gap);
-          }
-          result.success("success");
-        } else {
-          resultError("dtmf", "peerConnection is null", result);
-        }
-        break;
-      }
-      case "addCandidate": {
-        String peerConnectionId = call.argument("peerConnectionId");
-        Map<String, Object> candidate = call.argument("candidate");
-        peerConnectionAddICECandidate(new ConstraintsMap(candidate), peerConnectionId, result);
-        break;
-      }
-      case "getStats": {
-        String peerConnectionId = call.argument("peerConnectionId");
-        String trackId = call.argument("trackId");
-        peerConnectionGetStats(trackId, peerConnectionId, result);
-        break;
-      }
-      case "createDataChannel": {
-        String peerConnectionId = call.argument("peerConnectionId");
-        String label = call.argument("label");
-        Map<String, Object> dataChannelDict = call.argument("dataChannelDict");
-        createDataChannel(peerConnectionId, label, new ConstraintsMap(dataChannelDict), result);
-        break;
-      }
-      case "dataChannelSend": {
-        String peerConnectionId = call.argument("peerConnectionId");
-        int dataChannelId = call.argument("dataChannelId");
-        String type = call.argument("type");
-        Boolean isBinary = type.equals("binary");
-        ByteBuffer byteBuffer;
-        if (isBinary) {
-          byteBuffer = ByteBuffer.wrap(call.argument("data"));
-        } else {
-          try {
-            String data = call.argument("data");
-            byteBuffer = ByteBuffer.wrap(data.getBytes("UTF-8"));
-          } catch (UnsupportedEncodingException e) {
-            resultError("dataChannelSend", "Could not encode text string as UTF-8.", result);
+    private Activity activity;
+
+    MethodCallHandlerImpl(Context context, BinaryMessenger messenger, TextureRegistry textureRegistry,
+                          @NonNull AudioManager audioManager) {
+        this.context = context;
+        this.textures = textureRegistry;
+        this.messenger = messenger;
+        this.audioManager = audioManager;
+    }
+
+    static private void resultError(String method, String error, Result result) {
+        String errorMsg = method + "(): " + error;
+        result.error(method, errorMsg, null);
+        Log.d(TAG, errorMsg);
+    }
+
+    void dispose() {
+        mPeerConnectionObservers.clear();
+    }
+
+    private void ensureInitialized() {
+        if (mFactory != null) {
             return;
-          }
         }
-        dataChannelSend(peerConnectionId, dataChannelId, byteBuffer, isBinary);
-        result.success(null);
-        break;
-      }
-      case "dataChannelClose": {
-        String peerConnectionId = call.argument("peerConnectionId");
-        int dataChannelId = call.argument("dataChannelId");
-        dataChannelClose(peerConnectionId, dataChannelId);
-        result.success(null);
-        break;
-      }
-      case "streamDispose": {
-        String streamId = call.argument("streamId");
-        mediaStreamRelease(streamId);
-        result.success(null);
-        break;
-      }
-      case "mediaStreamTrackSetEnable": {
-        String trackId = call.argument("trackId");
-        Boolean enabled = call.argument("enabled");
-        MediaStreamTrack track = getTrackForId(trackId);
-        if (track != null) {
-          track.setEnabled(enabled);
-        }
-        result.success(null);
-        break;
-      }
-      case "mediaStreamAddTrack": {
-        String streamId = call.argument("streamId");
-        String trackId = call.argument("trackId");
-        mediaStreamAddTrack(streamId, trackId, result);
-        break;
-      }
-      case "mediaStreamRemoveTrack": {
-        String streamId = call.argument("streamId");
-        String trackId = call.argument("trackId");
-        mediaStreamRemoveTrack(streamId, trackId, result);
-        break;
-      }
-      case "trackDispose": {
-        String trackId = call.argument("trackId");
-        localTracks.remove(trackId);
-        result.success(null);
-        break;
-      }
-      case "peerConnectionClose": {
-        String peerConnectionId = call.argument("peerConnectionId");
-        peerConnectionClose(peerConnectionId);
-        result.success(null);
-        break;
-      }
-      case "peerConnectionDispose": {
-        String peerConnectionId = call.argument("peerConnectionId");
-        peerConnectionDispose(peerConnectionId);
-        result.success(null);
-        break;
-      }
-      case "createVideoRenderer": {
-        SurfaceTextureEntry entry = textures.createSurfaceTexture();
-        SurfaceTexture surfaceTexture = entry.surfaceTexture();
-        FlutterRTCVideoRenderer render = new FlutterRTCVideoRenderer(surfaceTexture, entry);
-        renders.put(entry.id(), render);
 
-        EventChannel eventChannel =
-            new EventChannel(
-                messenger,
-                "FlutterWebRTC/Texture" + entry.id());
+        PeerConnectionFactory.initialize(
+                InitializationOptions.builder(context)
+                        .setEnableInternalTracer(true)
+                        .createInitializationOptions());
 
-        eventChannel.setStreamHandler(render);
-        render.setEventChannel(eventChannel);
-        render.setId((int) entry.id());
+        // Initialize EGL contexts required for HW acceleration.
+        EglBase.Context eglContext = EglUtils.getRootEglBaseContext();
 
-        ConstraintsMap params = new ConstraintsMap();
-        params.putInt("textureId", (int) entry.id());
-        result.success(params.toMap());
-        break;
-      }
-      case "videoRendererDispose": {
-        int textureId = call.argument("textureId");
-        FlutterRTCVideoRenderer render = renders.get(textureId);
-        if (render == null) {
-          resultError("videoRendererDispose",  "render [" + textureId + "] not found !", result);
-          return;
+        getUserMediaImpl = new GetUserMediaImpl(this, context);
+
+        audioDeviceModule = JavaAudioDeviceModule.builder(context)
+                .setUseHardwareAcousticEchoCanceler(true)
+                .setUseHardwareNoiseSuppressor(true)
+                .setSamplesReadyCallback(getUserMediaImpl.inputSamplesInterceptor)
+                .createAudioDeviceModule();
+
+        getUserMediaImpl.audioDeviceModule = (JavaAudioDeviceModule) audioDeviceModule;
+
+        mFactory = PeerConnectionFactory.builder()
+                .setOptions(new Options())
+                .setVideoEncoderFactory(new DefaultVideoEncoderFactory(eglContext, false, true))
+                .setVideoDecoderFactory(new DefaultVideoDecoderFactory(eglContext))
+                .setAudioDeviceModule(audioDeviceModule)
+                .createPeerConnectionFactory();
+    }
+
+    @Override
+    public void onMethodCall(MethodCall call, @NonNull Result notSafeResult) {
+        ensureInitialized();
+
+        final AnyThreadResult result = new AnyThreadResult(notSafeResult);
+        switch (call.method) {
+            case "createPeerConnection": {
+                Map<String, Object> constraints = call.argument("constraints");
+                Map<String, Object> configuration = call.argument("configuration");
+                String peerConnectionId = peerConnectionInit(new ConstraintsMap(configuration),
+                        new ConstraintsMap((constraints)));
+                ConstraintsMap res = new ConstraintsMap();
+                res.putString("peerConnectionId", peerConnectionId);
+                result.success(res.toMap());
+                break;
+            }
+            case "getUserMedia": {
+                Map<String, Object> constraints = call.argument("constraints");
+                ConstraintsMap constraintsMap = new ConstraintsMap(constraints);
+                getUserMedia(constraintsMap, result);
+                break;
+            }
+            case "createLocalMediaStream":
+                createLocalMediaStream(result);
+                break;
+            case "getSources":
+                getSources(result);
+                break;
+            case "createOffer": {
+                String peerConnectionId = call.argument("peerConnectionId");
+                Map<String, Object> constraints = call.argument("constraints");
+                peerConnectionCreateOffer(peerConnectionId, new ConstraintsMap(constraints), result);
+                break;
+            }
+            case "createAnswer": {
+                String peerConnectionId = call.argument("peerConnectionId");
+                Map<String, Object> constraints = call.argument("constraints");
+                peerConnectionCreateAnswer(peerConnectionId, new ConstraintsMap(constraints), result);
+                break;
+            }
+            case "mediaStreamGetTracks": {
+                String streamId = call.argument("streamId");
+                MediaStream stream = getStreamForId(streamId, "");
+                Map<String, Object> resultMap = new HashMap<>();
+                List<Object> audioTracks = new ArrayList<>();
+                List<Object> videoTracks = new ArrayList<>();
+                for (AudioTrack track : stream.audioTracks) {
+                    localTracks.put(track.id(), track);
+                    Map<String, Object> trackMap = new HashMap<>();
+                    trackMap.put("enabled", track.enabled());
+                    trackMap.put("id", track.id());
+                    trackMap.put("kind", track.kind());
+                    trackMap.put("label", track.id());
+                    trackMap.put("readyState", "live");
+                    trackMap.put("remote", false);
+                    audioTracks.add(trackMap);
+                }
+                for (VideoTrack track : stream.videoTracks) {
+                    localTracks.put(track.id(), track);
+                    Map<String, Object> trackMap = new HashMap<>();
+                    trackMap.put("enabled", track.enabled());
+                    trackMap.put("id", track.id());
+                    trackMap.put("kind", track.kind());
+                    trackMap.put("label", track.id());
+                    trackMap.put("readyState", "live");
+                    trackMap.put("remote", false);
+                    videoTracks.add(trackMap);
+                }
+                resultMap.put("audioTracks", audioTracks);
+                resultMap.put("videoTracks", videoTracks);
+                result.success(resultMap);
+                break;
+            }
+            case "addStream": {
+                String streamId = call.argument("streamId");
+                String peerConnectionId = call.argument("peerConnectionId");
+                peerConnectionAddStream(streamId, peerConnectionId, result);
+                break;
+            }
+            case "removeStream": {
+                String streamId = call.argument("streamId");
+                String peerConnectionId = call.argument("peerConnectionId");
+                peerConnectionRemoveStream(streamId, peerConnectionId, result);
+                break;
+            }
+            case "setLocalDescription": {
+                String peerConnectionId = call.argument("peerConnectionId");
+                Map<String, Object> description = call.argument("description");
+                peerConnectionSetLocalDescription(new ConstraintsMap(description), peerConnectionId,
+                        result);
+                break;
+            }
+            case "setRemoteDescription": {
+                String peerConnectionId = call.argument("peerConnectionId");
+                Map<String, Object> description = call.argument("description");
+                peerConnectionSetRemoteDescription(new ConstraintsMap(description), peerConnectionId,
+                        result);
+                break;
+            }
+            case "sendDtmf": {
+                String peerConnectionId = call.argument("peerConnectionId");
+                String tone = call.argument("tone");
+                int duration = call.argument("duration");
+                int gap = call.argument("gap");
+                PeerConnection peerConnection = getPeerConnection(peerConnectionId);
+                if (peerConnection != null) {
+                    RtpSender audioSender = null;
+                    for (RtpSender sender : peerConnection.getSenders()) {
+
+                        if (sender.track().kind().equals("audio")) {
+                            audioSender = sender;
+                        }
+                    }
+                    if (audioSender != null) {
+                        DtmfSender dtmfSender = audioSender.dtmf();
+                        dtmfSender.insertDtmf(tone, duration, gap);
+                    }
+                    result.success("success");
+                } else {
+                    resultError("dtmf", "peerConnection is null", result);
+                }
+                break;
+            }
+            case "addCandidate": {
+                String peerConnectionId = call.argument("peerConnectionId");
+                Map<String, Object> candidate = call.argument("candidate");
+                peerConnectionAddICECandidate(new ConstraintsMap(candidate), peerConnectionId, result);
+                break;
+            }
+            case "getStats": {
+                String peerConnectionId = call.argument("peerConnectionId");
+                String trackId = call.argument("trackId");
+                peerConnectionGetStats(trackId, peerConnectionId, result);
+                break;
+            }
+            case "createDataChannel": {
+                String peerConnectionId = call.argument("peerConnectionId");
+                String label = call.argument("label");
+                Map<String, Object> dataChannelDict = call.argument("dataChannelDict");
+                createDataChannel(peerConnectionId, label, new ConstraintsMap(dataChannelDict), result);
+                break;
+            }
+            case "dataChannelSend": {
+                String peerConnectionId = call.argument("peerConnectionId");
+                int dataChannelId = call.argument("dataChannelId");
+                String type = call.argument("type");
+                Boolean isBinary = type.equals("binary");
+                ByteBuffer byteBuffer;
+                if (isBinary) {
+                    byteBuffer = ByteBuffer.wrap(call.argument("data"));
+                } else {
+                    try {
+                        String data = call.argument("data");
+                        byteBuffer = ByteBuffer.wrap(data.getBytes("UTF-8"));
+                    } catch (UnsupportedEncodingException e) {
+                        resultError("dataChannelSend", "Could not encode text string as UTF-8.", result);
+                        return;
+                    }
+                }
+                dataChannelSend(peerConnectionId, dataChannelId, byteBuffer, isBinary);
+                result.success(null);
+                break;
+            }
+            case "dataChannelClose": {
+                String peerConnectionId = call.argument("peerConnectionId");
+                int dataChannelId = call.argument("dataChannelId");
+                dataChannelClose(peerConnectionId, dataChannelId);
+                result.success(null);
+                break;
+            }
+            case "streamDispose": {
+                String streamId = call.argument("streamId");
+                mediaStreamRelease(streamId);
+                result.success(null);
+                break;
+            }
+            case "mediaStreamTrackSetEnable": {
+                String trackId = call.argument("trackId");
+                Boolean enabled = call.argument("enabled");
+                mediaStreamTrackSetEnabled(trackId, enabled);
+                result.success(null);
+                break;
+            }
+            case "mediaStreamAddTrack": {
+                String streamId = call.argument("streamId");
+                String trackId = call.argument("trackId");
+                mediaStreamAddTrack(streamId, trackId, result);
+                for (int i = 0; i < renders.size(); i++) {
+                    FlutterRTCVideoRenderer renderer = renders.get(i);
+                    if (renderer.checkMediaStream(streamId)) {
+                        renderer.setVideoTrack((VideoTrack) localTracks.get(trackId));
+                    }
+                }
+                break;
+            }
+            case "mediaStreamRemoveTrack": {
+                String streamId = call.argument("streamId");
+                String trackId = call.argument("trackId");
+                mediaStreamRemoveTrack(streamId, trackId, result);
+                for (int i = 0; i < renders.size(); i++) {
+                    FlutterRTCVideoRenderer renderer = renders.get(i);
+                    if (renderer.checkVideoTrack(trackId)) {
+                        renderer.setVideoTrack(null);
+                    }
+                }
+                break;
+            }
+            case "trackDispose": {
+                String trackId = call.argument("trackId");
+                localTracks.remove(trackId);
+                result.success(null);
+                break;
+            }
+            case "peerConnectionClose": {
+                String peerConnectionId = call.argument("peerConnectionId");
+                peerConnectionClose(peerConnectionId);
+                result.success(null);
+                break;
+            }
+            case "peerConnectionDispose": {
+                String peerConnectionId = call.argument("peerConnectionId");
+                peerConnectionDispose(peerConnectionId);
+                result.success(null);
+                break;
+            }
+            case "createVideoRenderer": {
+                SurfaceTextureEntry entry = textures.createSurfaceTexture();
+                SurfaceTexture surfaceTexture = entry.surfaceTexture();
+                FlutterRTCVideoRenderer render = new FlutterRTCVideoRenderer(surfaceTexture, entry);
+                renders.put(entry.id(), render);
+
+                EventChannel eventChannel =
+                        new EventChannel(
+                                messenger,
+                                "FlutterWebRTC/Texture" + entry.id());
+
+                eventChannel.setStreamHandler(render);
+                render.setEventChannel(eventChannel);
+                render.setId((int) entry.id());
+
+                ConstraintsMap params = new ConstraintsMap();
+                params.putInt("textureId", (int) entry.id());
+                result.success(params.toMap());
+                break;
+            }
+            case "videoRendererDispose": {
+                int textureId = call.argument("textureId");
+                FlutterRTCVideoRenderer render = renders.get(textureId);
+                if (render == null) {
+                    resultError("videoRendererDispose", "render [" + textureId + "] not found !", result);
+                    return;
+                }
+                render.Dispose();
+                renders.delete(textureId);
+                result.success(null);
+                break;
+            }
+            case "videoRendererSetSrcObject": {
+                int textureId = call.argument("textureId");
+                String streamId = call.argument("streamId");
+                String ownerTag = call.argument("ownerTag");
+                FlutterRTCVideoRenderer render = renders.get(textureId);
+                if (render == null) {
+                    resultError("videoRendererSetSrcObject", "render [" + textureId + "] not found !", result);
+                    return;
+                }
+                MediaStream stream = null;
+                if (ownerTag.equals("local")) {
+                    stream = localStreams.get(streamId);
+                } else {
+                    stream = getStreamForId(streamId, ownerTag);
+                }
+                render.setStream(stream);
+                result.success(null);
+                break;
+            }
+            case "mediaStreamTrackHasTorch": {
+                String trackId = call.argument("trackId");
+                getUserMediaImpl.hasTorch(trackId, result);
+                break;
+            }
+            case "mediaStreamTrackSetTorch": {
+                String trackId = call.argument("trackId");
+                boolean torch = call.argument("torch");
+                getUserMediaImpl.setTorch(trackId, torch, result);
+                break;
+            }
+            case "mediaStreamTrackSwitchCamera": {
+                String trackId = call.argument("trackId");
+                getUserMediaImpl.switchCamera(trackId, result);
+                break;
+            }
+            case "setVolume": {
+                String trackId = call.argument("trackId");
+                double volume = call.argument("volume");
+                mediaStreamTrackSetVolume(trackId, volume);
+                result.success(null);
+                break;
+            }
+            case "setMicrophoneMute":
+                boolean mute = call.argument("mute");
+                audioManager.setMicrophoneMute(mute);
+                result.success(null);
+                break;
+            case "enableSpeakerphone":
+                boolean enable = call.argument("enable");
+                audioManager.setSpeakerphoneOn(enable);
+                result.success(null);
+                break;
+            case "getDisplayMedia": {
+                Map<String, Object> constraints = call.argument("constraints");
+                ConstraintsMap constraintsMap = new ConstraintsMap(constraints);
+                getDisplayMedia(constraintsMap, result);
+                break;
+            }
+            case "startRecordToFile":
+                //This method can a lot of different exceptions
+                //so we should notify plugin user about them
+                try {
+                    String path = call.argument("path");
+                    VideoTrack videoTrack = null;
+                    String videoTrackId = call.argument("videoTrackId");
+                    if (videoTrackId != null) {
+                        MediaStreamTrack track = getTrackForId(videoTrackId);
+                        if (track instanceof VideoTrack) {
+                            videoTrack = (VideoTrack) track;
+                        }
+                    }
+                    AudioChannel audioChannel = null;
+                    if (call.hasArgument("audioChannel")
+                            && call.argument("audioChannel") != null) {
+                        audioChannel = AudioChannel.values()[(Integer) call.argument("audioChannel")];
+                    }
+                    Integer recorderId = call.argument("recorderId");
+                    if (videoTrack != null || audioChannel != null) {
+                        getUserMediaImpl.startRecordingToFile(path, recorderId, videoTrack, audioChannel);
+                        result.success(null);
+                    } else {
+                        resultError("startRecordToFile", "No tracks", result);
+                    }
+                } catch (Exception e) {
+                    resultError("startRecordToFile", e.getMessage(), result);
+                }
+                break;
+            case "stopRecordToFile":
+                Integer recorderId = call.argument("recorderId");
+                getUserMediaImpl.stopRecording(recorderId);
+                result.success(null);
+                break;
+            case "captureFrame":
+                String path = call.argument("path");
+                String videoTrackId = call.argument("trackId");
+                if (videoTrackId != null) {
+                    MediaStreamTrack track = getTrackForId(videoTrackId);
+                    if (track instanceof VideoTrack) {
+                        new FrameCapturer((VideoTrack) track, new File(path), result);
+                    } else {
+                        resultError("captureFrame", "It's not video track", result);
+                    }
+                } else {
+                    resultError("captureFrame", "Track is null", result);
+                }
+                break;
+            case "getLocalDescription": {
+                String peerConnectionId = call.argument("peerConnectionId");
+                PeerConnection peerConnection = getPeerConnection(peerConnectionId);
+                if (peerConnection != null) {
+                    SessionDescription sdp = peerConnection.getLocalDescription();
+                    ConstraintsMap params = new ConstraintsMap();
+                    params.putString("sdp", sdp.description);
+                    params.putString("type", sdp.type.canonicalForm());
+                    result.success(params.toMap());
+                } else {
+                    resultError("getLocalDescription", "peerConnection is nulll", result);
+                }
+                break;
+            }
+            case "getRemoteDescription": {
+                String peerConnectionId = call.argument("peerConnectionId");
+                PeerConnection peerConnection = getPeerConnection(peerConnectionId);
+                if (peerConnection != null) {
+                    SessionDescription sdp = peerConnection.getRemoteDescription();
+                    if (null == sdp) {
+                        result.success(null);
+                    } else {
+                        ConstraintsMap params = new ConstraintsMap();
+                        params.putString("sdp", sdp.description);
+                        params.putString("type", sdp.type.canonicalForm());
+                        result.success(params.toMap());
+                    }
+                } else {
+                    resultError("getRemoteDescription", "peerConnection is nulll", result);
+                }
+                break;
+            }
+            case "setConfiguration": {
+                String peerConnectionId = call.argument("peerConnectionId");
+                Map<String, Object> configuration = call.argument("configuration");
+                PeerConnection peerConnection = getPeerConnection(peerConnectionId);
+                if (peerConnection != null) {
+                    peerConnectionSetConfiguration(new ConstraintsMap(configuration), peerConnection);
+                    result.success(null);
+                } else {
+                    resultError("setConfiguration", "peerConnection is nulll", result);
+                }
+                break;
+            }
+            case "addTrack": {
+                String peerConnectionId = call.argument("peerConnectionId");
+                String trackId = call.argument("trackId");
+                List<String> streamIds = call.argument("streamIds");
+                addTrack(peerConnectionId, trackId, streamIds, result);
+                break;
+            }
+            case "removeTrack": {
+                String peerConnectionId = call.argument("peerConnectionId");
+                String senderId = call.argument("senderId");
+                removeTrack(peerConnectionId, senderId, result);
+                break;
+            }
+            case "addTransceiver": {
+                String peerConnectionId = call.argument("peerConnectionId");
+                Map<String, Object> transceiverInit = call.argument("transceiverInit");
+                if (call.hasArgument("trackId")) {
+                    String trackId = call.argument("trackId");
+                    addTransceiver(peerConnectionId, trackId, transceiverInit, result);
+                } else if (call.hasArgument("mediaType")) {
+                    String mediaType = call.argument("mediaType");
+                    addTransceiverOfType(peerConnectionId, mediaType, transceiverInit, result);
+                } else {
+                    resultError("addTransceiver", "Incomplete parameters", result);
+                }
+                break;
+            }
+            case "rtpTransceiverSetDirection": {
+                String peerConnectionId = call.argument("peerConnectionId");
+                String direction = call.argument("direction");
+                String transceiverId = call.argument("transceiverId");
+                rtpTransceiverSetDirection(peerConnectionId, direction, transceiverId, result);
+                break;
+            }
+            case "rtpTransceiverGetCurrentDirection": {
+                String peerConnectionId = call.argument("peerConnectionId");
+                String transceiverId = call.argument("transceiverId");
+                rtpTransceiverGetCurrentDirection(peerConnectionId, transceiverId, result);
+                break;
+            }
+            case "rtpTransceiverStop": {
+                String peerConnectionId = call.argument("peerConnectionId");
+                String transceiverId = call.argument("transceiverId");
+                rtpTransceiverStop(peerConnectionId, transceiverId, result);
+                break;
+            }
+            case "rtpSenderSetParameters": {
+                String peerConnectionId = call.argument("peerConnectionId");
+                String rtpSenderId = call.argument("rtpSenderId");
+                Map<String, Object> parameters = call.argument("parameters");
+                rtpSenderSetParameters(peerConnectionId, rtpSenderId, parameters, result);
+                break;
+            }
+            case "rtpSenderReplaceTrack": {
+                String peerConnectionId = call.argument("peerConnectionId");
+                String rtpSenderId = call.argument("rtpSenderId");
+                String trackId = call.argument("trackId");
+                rtpSenderSetTrack(peerConnectionId, rtpSenderId, trackId, true, result);
+                break;
+            }
+            case "rtpSenderSetTrack": {
+                String peerConnectionId = call.argument("peerConnectionId");
+                String rtpSenderId = call.argument("rtpSenderId");
+                String trackId = call.argument("trackId");
+                rtpSenderSetTrack(peerConnectionId, rtpSenderId, trackId, false, result);
+                break;
+            }
+            case "rtpSenderDispose": {
+                String peerConnectionId = call.argument("peerConnectionId");
+                String rtpSenderId = call.argument("rtpSenderId");
+                rtpSenderDispose(peerConnectionId, rtpSenderId, result);
+                break;
+            }
+            case "getSenders": {
+                String peerConnectionId = call.argument("peerConnectionId");
+                getSenders(peerConnectionId, result);
+                break;
+            }
+            case "getReceivers": {
+                String peerConnectionId = call.argument("peerConnectionId");
+                getReceivers(peerConnectionId, result);
+                break;
+            }
+            case "getTransceivers": {
+                String peerConnectionId = call.argument("peerConnectionId");
+                getTransceivers(peerConnectionId, result);
+                break;
+            }
+            default:
+                result.notImplemented();
+                break;
         }
-        render.Dispose();
-        renders.delete(textureId);
-        result.success(null);
-        break;
-      }
-      case "videoRendererSetSrcObject": {
-        int textureId = call.argument("textureId");
-        String streamId = call.argument("streamId");
-        String ownerTag = call.argument("ownerTag");
-        FlutterRTCVideoRenderer render = renders.get(textureId);
-        if (render == null) {
-          resultError("videoRendererSetSrcObject",  "render [" + textureId + "] not found !", result);
-          return;
+    }
+
+    private PeerConnection getPeerConnection(String id) {
+        PeerConnectionObserver pco = mPeerConnectionObservers.get(id);
+        return (pco == null) ? null : pco.getPeerConnection();
+    }
+
+    private List<IceServer> createIceServers(ConstraintsArray iceServersArray) {
+        final int size = (iceServersArray == null) ? 0 : iceServersArray.size();
+        List<IceServer> iceServers = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            ConstraintsMap iceServerMap = iceServersArray.getMap(i);
+            boolean hasUsernameAndCredential =
+                    iceServerMap.hasKey("username") && iceServerMap.hasKey("credential");
+            if (iceServerMap.hasKey("url")) {
+                if (hasUsernameAndCredential) {
+                    iceServers.add(IceServer.builder(iceServerMap.getString("url"))
+                            .setUsername(iceServerMap.getString("username"))
+                            .setPassword(iceServerMap.getString("credential")).createIceServer());
+                } else {
+                    iceServers.add(
+                            IceServer.builder(iceServerMap.getString("url")).createIceServer());
+                }
+            } else if (iceServerMap.hasKey("urls")) {
+                switch (iceServerMap.getType("urls")) {
+                    case String:
+                        if (hasUsernameAndCredential) {
+                            iceServers.add(IceServer.builder(iceServerMap.getString("urls"))
+                                    .setUsername(iceServerMap.getString("username"))
+                                    .setPassword(iceServerMap.getString("credential")).createIceServer());
+                        } else {
+                            iceServers.add(IceServer.builder(iceServerMap.getString("urls"))
+                                    .createIceServer());
+                        }
+                        break;
+                    case Array:
+                        ConstraintsArray urls = iceServerMap.getArray("urls");
+                        List<String> urlsList = new ArrayList<>();
+
+                        for (int j = 0; j < urls.size(); j++) {
+                            urlsList.add(urls.getString(j));
+                        }
+
+                        Builder builder = IceServer.builder(urlsList);
+
+                        if (hasUsernameAndCredential) {
+                            builder
+                                    .setUsername(iceServerMap.getString("username"))
+                                    .setPassword(iceServerMap.getString("credential"));
+                        }
+
+                        iceServers.add(builder.createIceServer());
+
+                        break;
+                }
+            }
         }
+        return iceServers;
+    }
+
+    private RTCConfiguration parseRTCConfiguration(ConstraintsMap map) {
+        ConstraintsArray iceServersArray = null;
+        if (map != null) {
+            iceServersArray = map.getArray("iceServers");
+        }
+        List<IceServer> iceServers = createIceServers(iceServersArray);
+        RTCConfiguration conf = new RTCConfiguration(iceServers);
+        if (map == null) {
+            return conf;
+        }
+
+        // iceTransportPolicy (public api)
+        if (map.hasKey("iceTransportPolicy")
+                && map.getType("iceTransportPolicy") == ObjectType.String) {
+            final String v = map.getString("iceTransportPolicy");
+            if (v != null) {
+                switch (v) {
+                    case "all": // public
+                        conf.iceTransportsType = IceTransportsType.ALL;
+                        break;
+                    case "relay": // public
+                        conf.iceTransportsType = IceTransportsType.RELAY;
+                        break;
+                    case "nohost":
+                        conf.iceTransportsType = IceTransportsType.NOHOST;
+                        break;
+                    case "none":
+                        conf.iceTransportsType = IceTransportsType.NONE;
+                        break;
+                }
+            }
+        }
+
+        // bundlePolicy (public api)
+        if (map.hasKey("bundlePolicy")
+                && map.getType("bundlePolicy") == ObjectType.String) {
+            final String v = map.getString("bundlePolicy");
+            if (v != null) {
+                switch (v) {
+                    case "balanced": // public
+                        conf.bundlePolicy = BundlePolicy.BALANCED;
+                        break;
+                    case "max-compat": // public
+                        conf.bundlePolicy = BundlePolicy.MAXCOMPAT;
+                        break;
+                    case "max-bundle": // public
+                        conf.bundlePolicy = BundlePolicy.MAXBUNDLE;
+                        break;
+                }
+            }
+        }
+
+        // rtcpMuxPolicy (public api)
+        if (map.hasKey("rtcpMuxPolicy")
+                && map.getType("rtcpMuxPolicy") == ObjectType.String) {
+            final String v = map.getString("rtcpMuxPolicy");
+            if (v != null) {
+                switch (v) {
+                    case "negotiate": // public
+                        conf.rtcpMuxPolicy = RtcpMuxPolicy.NEGOTIATE;
+                        break;
+                    case "require": // public
+                        conf.rtcpMuxPolicy = RtcpMuxPolicy.REQUIRE;
+                        break;
+                }
+            }
+        }
+
+        // FIXME: peerIdentity of type DOMString (public api)
+        // FIXME: certificates of type sequence<RTCCertificate> (public api)
+
+        // iceCandidatePoolSize of type unsigned short, defaulting to 0
+        if (map.hasKey("iceCandidatePoolSize")
+                && map.getType("iceCandidatePoolSize") == ObjectType.Number) {
+            final int v = map.getInt("iceCandidatePoolSize");
+            if (v > 0) {
+                conf.iceCandidatePoolSize = v;
+            }
+        }
+
+        // sdpSemantics
+        if (map.hasKey("sdpSemantics")
+                && map.getType("sdpSemantics") == ObjectType.String) {
+            final String v = map.getString("sdpSemantics");
+            if (v != null) {
+                switch (v) {
+                    case "plan-b":
+                        conf.sdpSemantics = SdpSemantics.PLAN_B;
+                        break;
+                    case "unified-plan":
+                        conf.sdpSemantics = SdpSemantics.UNIFIED_PLAN;
+                        break;
+                }
+            }
+        }
+
+        // === below is private api in webrtc ===
+
+        // tcpCandidatePolicy (private api)
+        if (map.hasKey("tcpCandidatePolicy")
+                && map.getType("tcpCandidatePolicy") == ObjectType.String) {
+            final String v = map.getString("tcpCandidatePolicy");
+            if (v != null) {
+                switch (v) {
+                    case "enabled":
+                        conf.tcpCandidatePolicy = TcpCandidatePolicy.ENABLED;
+                        break;
+                    case "disabled":
+                        conf.tcpCandidatePolicy = TcpCandidatePolicy.DISABLED;
+                        break;
+                }
+            }
+        }
+
+        // candidateNetworkPolicy (private api)
+        if (map.hasKey("candidateNetworkPolicy")
+                && map.getType("candidateNetworkPolicy") == ObjectType.String) {
+            final String v = map.getString("candidateNetworkPolicy");
+            if (v != null) {
+                switch (v) {
+                    case "all":
+                        conf.candidateNetworkPolicy = CandidateNetworkPolicy.ALL;
+                        break;
+                    case "low_cost":
+                        conf.candidateNetworkPolicy = CandidateNetworkPolicy.LOW_COST;
+                        break;
+                }
+            }
+        }
+
+        // KeyType (private api)
+        if (map.hasKey("keyType")
+                && map.getType("keyType") == ObjectType.String) {
+            final String v = map.getString("keyType");
+            if (v != null) {
+                switch (v) {
+                    case "RSA":
+                        conf.keyType = KeyType.RSA;
+                        break;
+                    case "ECDSA":
+                        conf.keyType = KeyType.ECDSA;
+                        break;
+                }
+            }
+        }
+
+        // continualGatheringPolicy (private api)
+        if (map.hasKey("continualGatheringPolicy")
+                && map.getType("continualGatheringPolicy") == ObjectType.String) {
+            final String v = map.getString("continualGatheringPolicy");
+            if (v != null) {
+                switch (v) {
+                    case "gather_once":
+                        conf.continualGatheringPolicy = ContinualGatheringPolicy.GATHER_ONCE;
+                        break;
+                    case "gather_continually":
+                        conf.continualGatheringPolicy = ContinualGatheringPolicy.GATHER_CONTINUALLY;
+                        break;
+                }
+            }
+        }
+
+        // audioJitterBufferMaxPackets (private api)
+        if (map.hasKey("audioJitterBufferMaxPackets")
+                && map.getType("audioJitterBufferMaxPackets") == ObjectType.Number) {
+            final int v = map.getInt("audioJitterBufferMaxPackets");
+            if (v > 0) {
+                conf.audioJitterBufferMaxPackets = v;
+            }
+        }
+
+        // iceConnectionReceivingTimeout (private api)
+        if (map.hasKey("iceConnectionReceivingTimeout")
+                && map.getType("iceConnectionReceivingTimeout") == ObjectType.Number) {
+            final int v = map.getInt("iceConnectionReceivingTimeout");
+            conf.iceConnectionReceivingTimeout = v;
+        }
+
+        // iceBackupCandidatePairPingInterval (private api)
+        if (map.hasKey("iceBackupCandidatePairPingInterval")
+                && map.getType("iceBackupCandidatePairPingInterval") == ObjectType.Number) {
+            final int v = map.getInt("iceBackupCandidatePairPingInterval");
+            conf.iceBackupCandidatePairPingInterval = v;
+        }
+
+        // audioJitterBufferFastAccelerate (private api)
+        if (map.hasKey("audioJitterBufferFastAccelerate")
+                && map.getType("audioJitterBufferFastAccelerate") == ObjectType.Boolean) {
+            final boolean v = map.getBoolean("audioJitterBufferFastAccelerate");
+            conf.audioJitterBufferFastAccelerate = v;
+        }
+
+        // pruneTurnPorts (private api)
+        if (map.hasKey("pruneTurnPorts")
+                && map.getType("pruneTurnPorts") == ObjectType.Boolean) {
+            final boolean v = map.getBoolean("pruneTurnPorts");
+            conf.pruneTurnPorts = v;
+        }
+
+        // presumeWritableWhenFullyRelayed (private api)
+        if (map.hasKey("presumeWritableWhenFullyRelayed")
+                && map.getType("presumeWritableWhenFullyRelayed") == ObjectType.Boolean) {
+            final boolean v = map.getBoolean("presumeWritableWhenFullyRelayed");
+            conf.presumeWritableWhenFullyRelayed = v;
+        }
+
+        return conf;
+    }
+
+    public String peerConnectionInit(ConstraintsMap configuration, ConstraintsMap constraints) {
+        String peerConnectionId = getNextStreamUUID();
+        RTCConfiguration conf = parseRTCConfiguration(configuration);
+        PeerConnectionObserver observer = new PeerConnectionObserver(conf, this, messenger, peerConnectionId);
+        PeerConnection peerConnection
+                = mFactory.createPeerConnection(
+                conf,
+                parseMediaConstraints(constraints),
+                observer);
+        observer.setPeerConnection(peerConnection);
+        if (mPeerConnectionObservers.size() == 0) {
+            audioManager.onAudioManagerRequested(true);
+        }
+        mPeerConnectionObservers.put(peerConnectionId, observer);
+        return peerConnectionId;
+    }
+
+    @Override
+    public Map<String, MediaStream> getLocalStreams() {
+        return localStreams;
+    }
+
+    @Override
+    public Map<String, MediaStreamTrack> getLocalTracks() {
+        return localTracks;
+    }
+
+    @Override
+    public String getNextStreamUUID() {
+        String uuid;
+
+        do {
+            uuid = UUID.randomUUID().toString();
+        } while (getStreamForId(uuid, "") != null);
+
+        return uuid;
+    }
+
+    @Override
+    public String getNextTrackUUID() {
+        String uuid;
+
+        do {
+            uuid = UUID.randomUUID().toString();
+        } while (getTrackForId(uuid) != null);
+
+        return uuid;
+    }
+
+    @Override
+    public PeerConnectionFactory getPeerConnectionFactory() {
+        return mFactory;
+    }
+
+    @Nullable
+    @Override
+    public Activity getActivity() {
+        return activity;
+    }
+
+    MediaStream getStreamForId(String id, String peerConnectionId) {
         MediaStream stream = null;
-        if (ownerTag.equals("local")) {
-          stream = localStreams.get(streamId);
-        } else  {
-          stream = getStreamForId(streamId, ownerTag);
-        }
-        render.setStream(stream);
-        result.success(null);
-        break;
-      }
-      case "mediaStreamTrackHasTorch": {
-        String trackId = call.argument("trackId");
-        getUserMediaImpl.hasTorch(trackId, result);
-        break;
-      }
-      case "mediaStreamTrackSetTorch": {
-        String trackId = call.argument("trackId");
-        boolean torch = call.argument("torch");
-        getUserMediaImpl.setTorch(trackId, torch, result);
-        break;
-      }
-      case "mediaStreamTrackSwitchCamera": {
-        String trackId = call.argument("trackId");
-        getUserMediaImpl.switchCamera(trackId, result);
-        break;
-      }
-      case "setVolume": {
-        String trackId = call.argument("trackId");
-        double volume = call.argument("volume");
-        mediaStreamTrackSetVolume(trackId, volume);
-        result.success(null);
-        break;
-      }
-      case "setMicrophoneMute":
-        boolean mute = call.argument("mute");
-        audioManager.setMicrophoneMute(mute);
-        result.success(null);
-        break;
-      case "enableSpeakerphone":
-        boolean enable = call.argument("enable");
-        audioManager.setSpeakerphoneOn(enable);
-        result.success(null);
-        break;
-      case "getDisplayMedia": {
-        Map<String, Object> constraints = call.argument("constraints");
-        ConstraintsMap constraintsMap = new ConstraintsMap(constraints);
-        getDisplayMedia(constraintsMap, result);
-        break;
-      }
-      case "startRecordToFile":
-        //This method can a lot of different exceptions
-        //so we should notify plugin user about them
-        try {
-          String path = call.argument("path");
-          VideoTrack videoTrack = null;
-          String videoTrackId = call.argument("videoTrackId");
-          if (videoTrackId != null) {
-            MediaStreamTrack track = getTrackForId(videoTrackId);
-            if (track instanceof VideoTrack) {
-              videoTrack = (VideoTrack) track;
+        if (peerConnectionId.length() > 0) {
+            PeerConnectionObserver pco = mPeerConnectionObservers.get(peerConnectionId);
+            if (pco != null) {
+                stream = pco.remoteStreams.get(id);
             }
-          }
-          AudioChannel audioChannel = null;
-          if (call.hasArgument("audioChannel")
-                  && call.argument("audioChannel") != null) {
-            audioChannel = AudioChannel.values()[(Integer) call.argument("audioChannel")];
-          }
-          Integer recorderId = call.argument("recorderId");
-          if (videoTrack != null || audioChannel != null) {
-            getUserMediaImpl.startRecordingToFile(path, recorderId, videoTrack, audioChannel);
-            result.success(null);
-          } else {
-            resultError("startRecordToFile", "No tracks", result);
-          }
-        } catch (Exception e) {
-          resultError("startRecordToFile", e.getMessage(), result);
-        }
-        break;
-      case "stopRecordToFile":
-        Integer recorderId = call.argument("recorderId");
-        getUserMediaImpl.stopRecording(recorderId);
-        result.success(null);
-        break;
-      case "captureFrame":
-        String path = call.argument("path");
-        String videoTrackId = call.argument("trackId");
-        if (videoTrackId != null) {
-          MediaStreamTrack track = getTrackForId(videoTrackId);
-          if (track instanceof VideoTrack) {
-            new FrameCapturer((VideoTrack) track, new File(path), result);
-          } else {
-            resultError("captureFrame", "It's not video track", result);
-          }
         } else {
-          resultError("captureFrame", "Track is null", result);
-        }
-        break;
-      case "getLocalDescription": {
-        String peerConnectionId = call.argument("peerConnectionId");
-        PeerConnection peerConnection = getPeerConnection(peerConnectionId);
-        if (peerConnection != null) {
-          SessionDescription sdp = peerConnection.getLocalDescription();
-          ConstraintsMap params = new ConstraintsMap();
-          params.putString("sdp", sdp.description);
-          params.putString("type", sdp.type.canonicalForm());
-          result.success(params.toMap());
-        } else {
-          resultError("getLocalDescription", "peerConnection is nulll", result);
-        }
-        break;
-      }
-      case "getRemoteDescription": {
-        String peerConnectionId = call.argument("peerConnectionId");
-        PeerConnection peerConnection = getPeerConnection(peerConnectionId);
-        if (peerConnection != null) {
-          SessionDescription sdp = peerConnection.getRemoteDescription();
-          ConstraintsMap params = new ConstraintsMap();
-          params.putString("sdp", sdp.description);
-          params.putString("type", sdp.type.canonicalForm());
-          result.success(params.toMap());
-        } else {
-          resultError("getRemoteDescription", "peerConnection is nulll", result);
-        }
-        break;
-      }
-      case "setConfiguration": {
-        String peerConnectionId = call.argument("peerConnectionId");
-        Map<String, Object> configuration = call.argument("configuration");
-        PeerConnection peerConnection = getPeerConnection(peerConnectionId);
-        if (peerConnection != null) {
-          peerConnectionSetConfiguration(new ConstraintsMap(configuration), peerConnection);
-          result.success(null);
-        } else {
-          resultError("setConfiguration", "peerConnection is nulll", result);
-        }
-        break;
-      }
-      case "addTrack": {
-        String peerConnectionId = call.argument("peerConnectionId");
-        String trackId = call.argument("trackId");
-        List<String> streamIds = call.argument("streamIds");
-        addTrack(peerConnectionId, trackId, streamIds, result);
-        break;
-      }
-      case "removeTrack": {
-        String peerConnectionId = call.argument("peerConnectionId");
-        String senderId = call.argument("senderId");
-        removeTrack(peerConnectionId, senderId, result);
-        break;
-      }
-      case "addTransceiver": {
-        String peerConnectionId = call.argument("peerConnectionId");
-        Map<String, Object> transceiverInit = call.argument("transceiverInit");
-        if(call.hasArgument("trackId")) {
-          String trackId = call.argument("trackId");
-          addTransceiver(peerConnectionId, trackId, transceiverInit, result);
-        } else  if(call.hasArgument("mediaType")) {
-          String mediaType = call.argument("mediaType");
-          addTransceiverOfType(peerConnectionId, mediaType, transceiverInit, result);
-        } else {
-          resultError("addTransceiver", "Incomplete parameters", result);
-        }
-        break;
-      }
-      case "rtpTransceiverSetDirection": {
-        String peerConnectionId = call.argument("peerConnectionId");
-        String direction = call.argument("direction");
-        String transceiverId = call.argument("transceiverId");
-        rtpTransceiverSetDirection(peerConnectionId, direction, transceiverId, result);
-        break;
-      }
-      case "rtpTransceiverGetCurrentDirection": {
-        String peerConnectionId = call.argument("peerConnectionId");
-        String transceiverId = call.argument("transceiverId");
-        rtpTransceiverGetCurrentDirection(peerConnectionId, transceiverId, result);
-        break;
-      }
-      case "rtpTransceiverStop": {
-        String peerConnectionId = call.argument("peerConnectionId");
-        String transceiverId = call.argument("transceiverId");
-        rtpTransceiverStop(peerConnectionId, transceiverId, result);
-        break;
-      }
-      case "rtpSenderSetParameters": {
-        String peerConnectionId = call.argument("peerConnectionId");
-        String rtpSenderId = call.argument("rtpSenderId");
-        Map<String, Object> parameters = call.argument("parameters");
-        rtpSenderSetParameters(peerConnectionId, rtpSenderId, parameters, result);
-        break;
-      }
-      case "rtpSenderReplaceTrack": {
-        String peerConnectionId = call.argument("peerConnectionId");
-        String rtpSenderId = call.argument("rtpSenderId");
-        String trackId = call.argument("trackId");
-        rtpSenderSetTrack(peerConnectionId, rtpSenderId, trackId, true, result);
-        break;
-      }
-      case "rtpSenderSetTrack": {
-        String peerConnectionId = call.argument("peerConnectionId");
-        String rtpSenderId = call.argument("rtpSenderId");
-        String trackId = call.argument("trackId");
-        rtpSenderSetTrack(peerConnectionId, rtpSenderId, trackId, false, result);
-        break;
-      }
-      case "rtpSenderDispose": {
-        String peerConnectionId = call.argument("peerConnectionId");
-        String rtpSenderId = call.argument("rtpSenderId");
-        rtpSenderDispose(peerConnectionId, rtpSenderId, result);
-        break;
-      }
-      case "getSenders": {
-        String peerConnectionId = call.argument("peerConnectionId");
-        getSenders(peerConnectionId, result);
-        break;
-      }
-      case "getReceivers": {
-        String peerConnectionId = call.argument("peerConnectionId");
-        getReceivers(peerConnectionId, result);
-        break;
-      }
-      case "getTransceivers": {
-        String peerConnectionId = call.argument("peerConnectionId");
-        getTransceivers(peerConnectionId, result);
-        break;
-      }
-      default:
-        result.notImplemented();
-        break;
-    }
-  }
-
-  private PeerConnection getPeerConnection(String id) {
-    PeerConnectionObserver pco = mPeerConnectionObservers.get(id);
-    return (pco == null) ? null : pco.getPeerConnection();
-  }
-
-  private List<IceServer> createIceServers(ConstraintsArray iceServersArray) {
-    final int size = (iceServersArray == null) ? 0 : iceServersArray.size();
-    List<IceServer> iceServers = new ArrayList<>(size);
-    for (int i = 0; i < size; i++) {
-      ConstraintsMap iceServerMap = iceServersArray.getMap(i);
-      boolean hasUsernameAndCredential =
-          iceServerMap.hasKey("username") && iceServerMap.hasKey("credential");
-      if (iceServerMap.hasKey("url")) {
-        if (hasUsernameAndCredential) {
-          iceServers.add(IceServer.builder(iceServerMap.getString("url"))
-              .setUsername(iceServerMap.getString("username"))
-              .setPassword(iceServerMap.getString("credential")).createIceServer());
-        } else {
-          iceServers.add(
-              IceServer.builder(iceServerMap.getString("url")).createIceServer());
-        }
-      } else if (iceServerMap.hasKey("urls")) {
-        switch (iceServerMap.getType("urls")) {
-          case String:
-            if (hasUsernameAndCredential) {
-              iceServers.add(IceServer.builder(iceServerMap.getString("urls"))
-                  .setUsername(iceServerMap.getString("username"))
-                  .setPassword(iceServerMap.getString("credential")).createIceServer());
-            } else {
-              iceServers.add(IceServer.builder(iceServerMap.getString("urls"))
-                  .createIceServer());
+            for (Entry<String, PeerConnectionObserver> entry : mPeerConnectionObservers
+                    .entrySet()) {
+                PeerConnectionObserver pco = entry.getValue();
+                stream = pco.remoteStreams.get(id);
+                if (stream != null) {
+                    break;
+                }
             }
-            break;
-          case Array:
-            ConstraintsArray urls = iceServerMap.getArray("urls");
-            List<String> urlsList = new ArrayList<>();
-
-            for (int j = 0; j < urls.size(); j++) {
-              urlsList.add(urls.getString(j));
-            }
-
-            Builder builder = IceServer.builder(urlsList);
-
-            if (hasUsernameAndCredential) {
-              builder
-                  .setUsername(iceServerMap.getString("username"))
-                  .setPassword(iceServerMap.getString("credential"));
-            }
-
-            iceServers.add(builder.createIceServer());
-
-            break;
         }
-      }
-    }
-    return iceServers;
-  }
-
-  private RTCConfiguration parseRTCConfiguration(ConstraintsMap map) {
-    ConstraintsArray iceServersArray = null;
-    if (map != null) {
-      iceServersArray = map.getArray("iceServers");
-    }
-    List<IceServer> iceServers = createIceServers(iceServersArray);
-    RTCConfiguration conf = new RTCConfiguration(iceServers);
-    if (map == null) {
-      return conf;
-    }
-
-    // iceTransportPolicy (public api)
-    if (map.hasKey("iceTransportPolicy")
-        && map.getType("iceTransportPolicy") == ObjectType.String) {
-      final String v = map.getString("iceTransportPolicy");
-      if (v != null) {
-        switch (v) {
-          case "all": // public
-            conf.iceTransportsType = IceTransportsType.ALL;
-            break;
-          case "relay": // public
-            conf.iceTransportsType = IceTransportsType.RELAY;
-            break;
-          case "nohost":
-            conf.iceTransportsType = IceTransportsType.NOHOST;
-            break;
-          case "none":
-            conf.iceTransportsType = IceTransportsType.NONE;
-            break;
+        if (stream == null) {
+            stream = localStreams.get(id);
         }
-      }
+
+        return stream;
     }
 
-    // bundlePolicy (public api)
-    if (map.hasKey("bundlePolicy")
-        && map.getType("bundlePolicy") == ObjectType.String) {
-      final String v = map.getString("bundlePolicy");
-      if (v != null) {
-        switch (v) {
-          case "balanced": // public
-            conf.bundlePolicy = BundlePolicy.BALANCED;
-            break;
-          case "max-compat": // public
-            conf.bundlePolicy = BundlePolicy.MAXCOMPAT;
-            break;
-          case "max-bundle": // public
-            conf.bundlePolicy = BundlePolicy.MAXBUNDLE;
-            break;
-        }
-      }
-    }
-
-    // rtcpMuxPolicy (public api)
-    if (map.hasKey("rtcpMuxPolicy")
-        && map.getType("rtcpMuxPolicy") == ObjectType.String) {
-      final String v = map.getString("rtcpMuxPolicy");
-      if (v != null) {
-        switch (v) {
-          case "negotiate": // public
-            conf.rtcpMuxPolicy = RtcpMuxPolicy.NEGOTIATE;
-            break;
-          case "require": // public
-            conf.rtcpMuxPolicy = RtcpMuxPolicy.REQUIRE;
-            break;
-        }
-      }
-    }
-
-    // FIXME: peerIdentity of type DOMString (public api)
-    // FIXME: certificates of type sequence<RTCCertificate> (public api)
-
-    // iceCandidatePoolSize of type unsigned short, defaulting to 0
-    if (map.hasKey("iceCandidatePoolSize")
-        && map.getType("iceCandidatePoolSize") == ObjectType.Number) {
-      final int v = map.getInt("iceCandidatePoolSize");
-      if (v > 0) {
-        conf.iceCandidatePoolSize = v;
-      }
-    }
-
-    // sdpSemantics
-    if (map.hasKey("sdpSemantics")
-        && map.getType("sdpSemantics") == ObjectType.String) {
-      final String v = map.getString("sdpSemantics");
-      if (v != null) {
-        switch (v) {
-          case "plan-b":
-            conf.sdpSemantics = SdpSemantics.PLAN_B;
-            break;
-          case "unified-plan":
-            conf.sdpSemantics = SdpSemantics.UNIFIED_PLAN;
-            break;
-        }
-      }
-    }
-
-    // === below is private api in webrtc ===
-
-    // tcpCandidatePolicy (private api)
-    if (map.hasKey("tcpCandidatePolicy")
-        && map.getType("tcpCandidatePolicy") == ObjectType.String) {
-      final String v = map.getString("tcpCandidatePolicy");
-      if (v != null) {
-        switch (v) {
-          case "enabled":
-            conf.tcpCandidatePolicy = TcpCandidatePolicy.ENABLED;
-            break;
-          case "disabled":
-            conf.tcpCandidatePolicy = TcpCandidatePolicy.DISABLED;
-            break;
-        }
-      }
-    }
-
-    // candidateNetworkPolicy (private api)
-    if (map.hasKey("candidateNetworkPolicy")
-        && map.getType("candidateNetworkPolicy") == ObjectType.String) {
-      final String v = map.getString("candidateNetworkPolicy");
-      if (v != null) {
-        switch (v) {
-          case "all":
-            conf.candidateNetworkPolicy = CandidateNetworkPolicy.ALL;
-            break;
-          case "low_cost":
-            conf.candidateNetworkPolicy = CandidateNetworkPolicy.LOW_COST;
-            break;
-        }
-      }
-    }
-
-    // KeyType (private api)
-    if (map.hasKey("keyType")
-        && map.getType("keyType") == ObjectType.String) {
-      final String v = map.getString("keyType");
-      if (v != null) {
-        switch (v) {
-          case "RSA":
-            conf.keyType = KeyType.RSA;
-            break;
-          case "ECDSA":
-            conf.keyType = KeyType.ECDSA;
-            break;
-        }
-      }
-    }
-
-    // continualGatheringPolicy (private api)
-    if (map.hasKey("continualGatheringPolicy")
-        && map.getType("continualGatheringPolicy") == ObjectType.String) {
-      final String v = map.getString("continualGatheringPolicy");
-      if (v != null) {
-        switch (v) {
-          case "gather_once":
-            conf.continualGatheringPolicy = ContinualGatheringPolicy.GATHER_ONCE;
-            break;
-          case "gather_continually":
-            conf.continualGatheringPolicy = ContinualGatheringPolicy.GATHER_CONTINUALLY;
-            break;
-        }
-      }
-    }
-
-    // audioJitterBufferMaxPackets (private api)
-    if (map.hasKey("audioJitterBufferMaxPackets")
-        && map.getType("audioJitterBufferMaxPackets") == ObjectType.Number) {
-      final int v = map.getInt("audioJitterBufferMaxPackets");
-      if (v > 0) {
-        conf.audioJitterBufferMaxPackets = v;
-      }
-    }
-
-    // iceConnectionReceivingTimeout (private api)
-    if (map.hasKey("iceConnectionReceivingTimeout")
-        && map.getType("iceConnectionReceivingTimeout") == ObjectType.Number) {
-      final int v = map.getInt("iceConnectionReceivingTimeout");
-      conf.iceConnectionReceivingTimeout = v;
-    }
-
-    // iceBackupCandidatePairPingInterval (private api)
-    if (map.hasKey("iceBackupCandidatePairPingInterval")
-        && map.getType("iceBackupCandidatePairPingInterval") == ObjectType.Number) {
-      final int v = map.getInt("iceBackupCandidatePairPingInterval");
-      conf.iceBackupCandidatePairPingInterval = v;
-    }
-
-    // audioJitterBufferFastAccelerate (private api)
-    if (map.hasKey("audioJitterBufferFastAccelerate")
-        && map.getType("audioJitterBufferFastAccelerate") == ObjectType.Boolean) {
-      final boolean v = map.getBoolean("audioJitterBufferFastAccelerate");
-      conf.audioJitterBufferFastAccelerate = v;
-    }
-
-    // pruneTurnPorts (private api)
-    if (map.hasKey("pruneTurnPorts")
-        && map.getType("pruneTurnPorts") == ObjectType.Boolean) {
-      final boolean v = map.getBoolean("pruneTurnPorts");
-      conf.pruneTurnPorts = v;
-    }
-
-    // presumeWritableWhenFullyRelayed (private api)
-    if (map.hasKey("presumeWritableWhenFullyRelayed")
-        && map.getType("presumeWritableWhenFullyRelayed") == ObjectType.Boolean) {
-      final boolean v = map.getBoolean("presumeWritableWhenFullyRelayed");
-      conf.presumeWritableWhenFullyRelayed = v;
-    }
-
-    return conf;
-  }
-
-  public String peerConnectionInit(ConstraintsMap configuration, ConstraintsMap constraints) {
-    String peerConnectionId = getNextStreamUUID();
-    RTCConfiguration conf =  parseRTCConfiguration(configuration);
-    PeerConnectionObserver observer = new PeerConnectionObserver(conf,this, messenger, peerConnectionId);
-    PeerConnection peerConnection
-        = mFactory.createPeerConnection(
-        conf,
-        parseMediaConstraints(constraints),
-        observer);
-    observer.setPeerConnection(peerConnection);
-    if (mPeerConnectionObservers.size() == 0) {
-      audioManager.onAudioManagerRequested(true);
-    }
-    mPeerConnectionObservers.put(peerConnectionId, observer);
-    return peerConnectionId;
-  }
-
-  @Override
-  public Map<String, MediaStream> getLocalStreams() {
-    return localStreams;
-  }
-
-  @Override
-  public Map<String, MediaStreamTrack> getLocalTracks() {
-    return localTracks;
-  }
-
-  @Override
-  public String getNextStreamUUID() {
-    String uuid;
-
-    do {
-      uuid = UUID.randomUUID().toString();
-    } while (getStreamForId(uuid, "") != null);
-
-    return uuid;
-  }
-
-  @Override
-  public String getNextTrackUUID() {
-    String uuid;
-
-    do {
-      uuid = UUID.randomUUID().toString();
-    } while (getTrackForId(uuid) != null);
-
-    return uuid;
-  }
-
-  @Override
-  public PeerConnectionFactory getPeerConnectionFactory() {
-    return mFactory;
-  }
-
-  @Nullable
-  @Override
-  public Activity getActivity() {
-    return activity;
-  }
-
-  MediaStream getStreamForId(String id, String peerConnectionId) {
-    MediaStream stream = null;
-    if (peerConnectionId.length() > 0) {
-      PeerConnectionObserver pco = mPeerConnectionObservers.get(peerConnectionId);
-      if (pco != null) {
-        stream = pco.remoteStreams.get(id);
-      }
-    } else {
-      for (Entry<String, PeerConnectionObserver> entry : mPeerConnectionObservers
-              .entrySet()) {
-        PeerConnectionObserver pco = entry.getValue();
-        stream = pco.remoteStreams.get(id);
-        if (stream != null) {
-          break;
-        }
-      }
-    }
-    if (stream == null) {
-      stream = localStreams.get(id);
-    }
-
-    return stream;
-  }
-
-  private MediaStreamTrack getTrackForId(String trackId) {
-    MediaStreamTrack track = localTracks.get(trackId);
-
-    if (track == null) {
-      for (Entry<String, PeerConnectionObserver> entry : mPeerConnectionObservers.entrySet()) {
-        PeerConnectionObserver pco = entry.getValue();
-        track = pco.remoteTracks.get(trackId);
+    private MediaStreamTrack getTrackForId(String trackId) {
+        MediaStreamTrack track = localTracks.get(trackId);
 
         if (track == null) {
-          track = pco.getTransceiversTrack(trackId);
+            for (Entry<String, PeerConnectionObserver> entry : mPeerConnectionObservers.entrySet()) {
+                PeerConnectionObserver pco = entry.getValue();
+                track = pco.remoteTracks.get(trackId);
+
+                if (track == null) {
+                    track = pco.getTransceiversTrack(trackId);
+                }
+
+                if (track != null) {
+                    break;
+                }
+            }
         }
 
-        if (track != null) {
-          break;
+        return track;
+    }
+
+
+    public void getUserMedia(ConstraintsMap constraints, Result result) {
+        String streamId = getNextStreamUUID();
+        MediaStream mediaStream = mFactory.createLocalMediaStream(streamId);
+
+        if (mediaStream == null) {
+            // XXX The following does not follow the getUserMedia() algorithm
+            // specified by
+            // https://www.w3.org/TR/mediacapture-streams/#dom-mediadevices-getusermedia
+            // with respect to distinguishing the various causes of failure.
+            resultError("getUserMediaFailed", "Failed to create new media stream", result);
+            return;
         }
-      }
+
+        getUserMediaImpl.getUserMedia(constraints, result, mediaStream);
     }
 
-    return track;
-  }
+    public void getDisplayMedia(ConstraintsMap constraints, Result result) {
+        String streamId = getNextStreamUUID();
+        MediaStream mediaStream = mFactory.createLocalMediaStream(streamId);
 
+        if (mediaStream == null) {
+            // XXX The following does not follow the getUserMedia() algorithm
+            // specified by
+            // https://www.w3.org/TR/mediacapture-streams/#dom-mediadevices-getusermedia
+            // with respect to distinguishing the various causes of failure.
+            resultError("getDisplayMedia", "Failed to create new media stream", result);
+            return;
+        }
 
-  public void getUserMedia(ConstraintsMap constraints, Result result) {
-    String streamId = getNextStreamUUID();
-    MediaStream mediaStream = mFactory.createLocalMediaStream(streamId);
-
-    if (mediaStream == null) {
-      // XXX The following does not follow the getUserMedia() algorithm
-      // specified by
-      // https://www.w3.org/TR/mediacapture-streams/#dom-mediadevices-getusermedia
-      // with respect to distinguishing the various causes of failure.
-      resultError("getUserMediaFailed", "Failed to create new media stream", result);
-      return;
+        getUserMediaImpl.getDisplayMedia(constraints, result, mediaStream);
     }
 
-    getUserMediaImpl.getUserMedia(constraints, result, mediaStream);
-  }
+    public void getSources(Result result) {
+        ConstraintsArray array = new ConstraintsArray();
+        String[] names = new String[Camera.getNumberOfCameras()];
 
-  public void getDisplayMedia(ConstraintsMap constraints, Result result) {
-    String streamId = getNextStreamUUID();
-    MediaStream mediaStream = mFactory.createLocalMediaStream(streamId);
+        for (int i = 0; i < Camera.getNumberOfCameras(); ++i) {
+            ConstraintsMap info = getCameraInfo(i);
+            if (info != null) {
+                array.pushMap(info);
+            }
+        }
 
-    if (mediaStream == null) {
-      // XXX The following does not follow the getUserMedia() algorithm
-      // specified by
-      // https://www.w3.org/TR/mediacapture-streams/#dom-mediadevices-getusermedia
-      // with respect to distinguishing the various causes of failure.
-      resultError("getDisplayMedia", "Failed to create new media stream", result);
-      return;
+        ConstraintsMap audio = new ConstraintsMap();
+        audio.putString("label", "Audio");
+        audio.putString("deviceId", "audio-1");
+        audio.putString("facing", "");
+        audio.putString("kind", "audioinput");
+        array.pushMap(audio);
+
+        ConstraintsMap map = new ConstraintsMap();
+        map.putArray("sources", array.toArrayList());
+
+        result.success(map.toMap());
     }
 
-    getUserMediaImpl.getDisplayMedia(constraints, result, mediaStream);
-  }
+    private void createLocalMediaStream(Result result) {
+        String streamId = getNextStreamUUID();
+        MediaStream mediaStream = mFactory.createLocalMediaStream(streamId);
+        localStreams.put(streamId, mediaStream);
 
-  public void getSources(Result result) {
-    ConstraintsArray array = new ConstraintsArray();
-    String[] names = new String[Camera.getNumberOfCameras()];
-
-    for (int i = 0; i < Camera.getNumberOfCameras(); ++i) {
-      ConstraintsMap info = getCameraInfo(i);
-      if (info != null) {
-        array.pushMap(info);
-      }
+        if (mediaStream == null) {
+            resultError("createLocalMediaStream", "Failed to create new media stream", result);
+            return;
+        }
+        Map<String, Object> resultMap = new HashMap<>();
+        resultMap.put("streamId", mediaStream.getId());
+        result.success(resultMap);
     }
 
-    ConstraintsMap audio = new ConstraintsMap();
-    audio.putString("label", "Audio");
-    audio.putString("deviceId", "audio-1");
-    audio.putString("facing", "");
-    audio.putString("kind", "audioinput");
-    array.pushMap(audio);
-    
-    ConstraintsMap map = new ConstraintsMap();
-    map.putArray("sources", array.toArrayList());
-    
-    result.success(map.toMap());
-  }
-
-  private void createLocalMediaStream(Result result) {
-    String streamId = getNextStreamUUID();
-    MediaStream mediaStream = mFactory.createLocalMediaStream(streamId);
-    localStreams.put(streamId, mediaStream);
-
-    if (mediaStream == null) {
-      resultError("createLocalMediaStream", "Failed to create new media stream", result);
-      return;
+    public void mediaStreamTrackStop(final String id) {
+        // Is this functionality equivalent to `mediaStreamTrackRelease()` ?
+        // if so, we should merge this two and remove track from stream as well.
+        MediaStreamTrack track = localTracks.get(id);
+        if (track == null) {
+            Log.d(TAG, "mediaStreamTrackStop() track is null");
+            return;
+        }
+        track.setEnabled(false);
+        if (track.kind().equals("video")) {
+            getUserMediaImpl.removeVideoCapturer(id);
+        }
+        localTracks.remove(id);
+        // What exactly does `detached` mean in doc?
+        // see: https://www.w3.org/TR/mediacapture-streams/#track-detached
     }
-    Map<String, Object> resultMap = new HashMap<>();
-    resultMap.put("streamId", mediaStream.getId());
-    result.success(resultMap);
-  }
 
-  public void mediaStreamTrackStop(final String id) {
-    // Is this functionality equivalent to `mediaStreamTrackRelease()` ?
-    // if so, we should merge this two and remove track from stream as well.
-    MediaStreamTrack track = localTracks.get(id);
-    if (track == null) {
-      Log.d(TAG, "mediaStreamTrackStop() track is null");
-      return;
-    }
-    track.setEnabled(false);
-    if (track.kind().equals("video")) {
-      getUserMediaImpl.removeVideoCapturer(id);
-    }
-    localTracks.remove(id);
-    // What exactly does `detached` mean in doc?
-    // see: https://www.w3.org/TR/mediacapture-streams/#track-detached
-  }
+    public void mediaStreamTrackSetEnabled(final String id, final boolean enabled) {
+        MediaStreamTrack track = localTracks.get(id);
 
-  public void mediaStreamTrackSetEnabled(final String id, final boolean enabled) {
-    MediaStreamTrack track = localTracks.get(id);
-    if (track == null) {
-      Log.d(TAG, "mediaStreamTrackSetEnabled() track is null");
-      return;
-    } else if (track.enabled() == enabled) {
-      return;
+        if (track == null) {
+            Log.d(TAG, "mediaStreamTrackSetEnabled() track is null");
+            return;
+        } else if (track.enabled() == enabled) {
+            return;
+        }
+        track.setEnabled(enabled);
     }
-    track.setEnabled(enabled);
-  }
 
-  public void mediaStreamTrackSetVolume(final String id, final double volume) {
-    MediaStreamTrack track = localTracks.get(id);
-    if (track != null && track instanceof AudioTrack) {
-      Log.d(TAG, "setVolume(): " + id + "," + volume);
-      try {
-        ((AudioTrack) track).setVolume(volume);
-      } catch (Exception e) {
-        Log.e(TAG, "setVolume(): error", e);
-      }
-    } else {
-      Log.w(TAG, "setVolume(): track not found: " + id);
+    public void mediaStreamTrackSetVolume(final String id, final double volume) {
+        MediaStreamTrack track = localTracks.get(id);
+        if (track != null && track instanceof AudioTrack) {
+            Log.d(TAG, "setVolume(): " + id + "," + volume);
+            try {
+                ((AudioTrack) track).setVolume(volume);
+            } catch (Exception e) {
+                Log.e(TAG, "setVolume(): error", e);
+            }
+        } else {
+            Log.w(TAG, "setVolume(): track not found: " + id);
+        }
     }
-  }
 
-  public void mediaStreamAddTrack(final String streamId, final String trackId, Result result) {
-    MediaStream mediaStream = localStreams.get(streamId);
-    if (mediaStream != null) {
-      MediaStreamTrack track = getTrackForId(trackId);//localTracks.get(trackId);
-      if (track != null) {
+    public void mediaStreamAddTrack(final String streamId, final String trackId, Result result) {
+        MediaStream mediaStream = localStreams.get(streamId);
+        if (mediaStream != null) {
+            MediaStreamTrack track = getTrackForId(trackId);//localTracks.get(trackId);
+            if (track != null) {
+                if (track.kind().equals("audio")) {
+                    mediaStream.addTrack((AudioTrack) track);
+                } else if (track.kind().equals("video")) {
+                    mediaStream.addTrack((VideoTrack) track);
+                }
+            } else {
+                resultError("mediaStreamAddTrack", "mediaStreamAddTrack() track [" + trackId + "] is null", result);
+            }
+        } else {
+            resultError("mediaStreamAddTrack", "mediaStreamAddTrack() stream [" + streamId + "] is null", result);
+        }
+        result.success(null);
+    }
+
+    public void mediaStreamRemoveTrack(final String streamId, final String trackId, Result result) {
+        MediaStream mediaStream = localStreams.get(streamId);
+        if (mediaStream != null) {
+            MediaStreamTrack track = localTracks.get(trackId);
+            if (track != null) {
+                if (track.kind().equals("audio")) {
+                    mediaStream.removeTrack((AudioTrack) track);
+                } else if (track.kind().equals("video")) {
+                    mediaStream.removeTrack((VideoTrack) track);
+                }
+            } else {
+                resultError("mediaStreamRemoveTrack", "mediaStreamAddTrack() track [" + trackId + "] is null", result);
+            }
+        } else {
+            resultError("mediaStreamRemoveTrack", "mediaStreamAddTrack() stream [" + streamId + "] is null", result);
+        }
+        result.success(null);
+    }
+
+    public void mediaStreamTrackRelease(final String streamId, final String _trackId) {
+        MediaStream stream = localStreams.get(streamId);
+        if (stream == null) {
+            Log.d(TAG, "mediaStreamTrackRelease() stream is null");
+            return;
+        }
+        MediaStreamTrack track = localTracks.get(_trackId);
+        if (track == null) {
+            Log.d(TAG, "mediaStreamTrackRelease() track is null");
+            return;
+        }
+        track.setEnabled(false); // should we do this?
+        localTracks.remove(_trackId);
         if (track.kind().equals("audio")) {
-          mediaStream.addTrack((AudioTrack) track);
+            stream.removeTrack((AudioTrack) track);
         } else if (track.kind().equals("video")) {
-          mediaStream.addTrack((VideoTrack) track);
+            stream.removeTrack((VideoTrack) track);
+            getUserMediaImpl.removeVideoCapturer(_trackId);
         }
-      } else {
-        resultError("mediaStreamAddTrack", "mediaStreamAddTrack() track [" + trackId + "] is null", result);
-      }
-    } else {
-      resultError("mediaStreamAddTrack", "mediaStreamAddTrack() stream [" + streamId + "] is null", result);
     }
-    result.success(null);
-  }
 
-  public void mediaStreamRemoveTrack(final String streamId, final String trackId, Result result) {
-    MediaStream mediaStream = localStreams.get(streamId);
-    if (mediaStream != null) {
-      MediaStreamTrack track = localTracks.get(trackId);
-      if (track != null) {
-        if (track.kind().equals("audio")) {
-          mediaStream.removeTrack((AudioTrack) track);
-        } else if (track.kind().equals("video")) {
-          mediaStream.removeTrack((VideoTrack) track);
+    public ConstraintsMap getCameraInfo(int index) {
+        CameraInfo info = new CameraInfo();
+
+        try {
+            Camera.getCameraInfo(index, info);
+        } catch (Exception e) {
+            Logging.e("CameraEnumerationAndroid", "getCameraInfo failed on index " + index, e);
+            return null;
         }
-      } else {
-        resultError("mediaStreamRemoveTrack", "mediaStreamAddTrack() track [" + trackId + "] is null", result);
-      }
-    } else {
-      resultError("mediaStreamRemoveTrack", "mediaStreamAddTrack() stream [" + streamId + "] is null", result);
+        ConstraintsMap params = new ConstraintsMap();
+        String facing = info.facing == 1 ? "front" : "back";
+        params.putString("label",
+                "Camera " + index + ", Facing " + facing + ", Orientation " + info.orientation);
+        params.putString("deviceId", "" + index);
+        params.putString("facing", facing);
+        params.putString("kind", "videoinput");
+        return params;
     }
-    result.success(null);
-  }
 
-  public void mediaStreamTrackRelease(final String streamId, final String _trackId) {
-    MediaStream stream = localStreams.get(streamId);
-    if (stream == null) {
-      Log.d(TAG, "mediaStreamTrackRelease() stream is null");
-      return;
+    private MediaConstraints defaultConstraints() {
+        MediaConstraints constraints = new MediaConstraints();
+        // TODO video media
+        constraints.mandatory.add(new KeyValuePair("OfferToReceiveAudio", "true"));
+        constraints.mandatory.add(new KeyValuePair("OfferToReceiveVideo", "true"));
+        constraints.optional.add(new KeyValuePair("DtlsSrtpKeyAgreement", "true"));
+        return constraints;
     }
-    MediaStreamTrack track = localTracks.get(_trackId);
-    if (track == null) {
-      Log.d(TAG, "mediaStreamTrackRelease() track is null");
-      return;
-    }
-    track.setEnabled(false); // should we do this?
-    localTracks.remove(_trackId);
-    if (track.kind().equals("audio")) {
-      stream.removeTrack((AudioTrack) track);
-    } else if (track.kind().equals("video")) {
-      stream.removeTrack((VideoTrack) track);
-      getUserMediaImpl.removeVideoCapturer(_trackId);
-    }
-  }
 
-  public ConstraintsMap getCameraInfo(int index) {
-    CameraInfo info = new CameraInfo();
-
-    try {
-      Camera.getCameraInfo(index, info);
-    } catch (Exception e) {
-      Logging.e("CameraEnumerationAndroid", "getCameraInfo failed on index " + index, e);
-      return null;
-    }
-    ConstraintsMap params = new ConstraintsMap();
-    String facing = info.facing == 1 ? "front" : "back";
-    params.putString("label",
-        "Camera " + index + ", Facing " + facing + ", Orientation " + info.orientation);
-    params.putString("deviceId", "" + index);
-    params.putString("facing", facing);
-    params.putString("kind", "videoinput");
-    return params;
-  }
-
-  private MediaConstraints defaultConstraints() {
-    MediaConstraints constraints = new MediaConstraints();
-    // TODO video media
-    constraints.mandatory.add(new KeyValuePair("OfferToReceiveAudio", "true"));
-    constraints.mandatory.add(new KeyValuePair("OfferToReceiveVideo", "true"));
-    constraints.optional.add(new KeyValuePair("DtlsSrtpKeyAgreement", "true"));
-    return constraints;
-  }
-
-  public void peerConnectionSetConfiguration(ConstraintsMap configuration,
-      PeerConnection peerConnection) {
-    if (peerConnection == null) {
-      Log.d(TAG, "peerConnectionSetConfiguration() peerConnection is null");
-      return;
-    }
-    peerConnection.setConfiguration(parseRTCConfiguration(configuration));
-  }
-
-  public void peerConnectionAddStream(final String streamId, final String id, Result result) {
-    MediaStream mediaStream = localStreams.get(streamId);
-    if (mediaStream == null) {
-      Log.d(TAG, "peerConnectionAddStream() mediaStream is null");
-      return;
-    }
-    PeerConnection peerConnection = getPeerConnection(id);
-    if (peerConnection != null) {
-      boolean res = peerConnection.addStream(mediaStream);
-      Log.d(TAG, "addStream" + result);
-      result.success(res);
-    } else {
-      resultError("peerConnectionAddStream", "peerConnection is null", result);
-    }
-  }
-
-  public void peerConnectionRemoveStream(final String streamId, final String id, Result result) {
-    MediaStream mediaStream = localStreams.get(streamId);
-    if (mediaStream == null) {
-      Log.d(TAG, "peerConnectionRemoveStream() mediaStream is null");
-      return;
-    }
-    PeerConnection peerConnection = getPeerConnection(id);
-    if (peerConnection != null) {
-      peerConnection.removeStream(mediaStream);
-      result.success(null);
-    } else {
-      resultError("peerConnectionRemoveStream", "peerConnection is null", result);
-    }
-  }
-
-  public void peerConnectionCreateOffer(
-      String id,
-      ConstraintsMap constraints,
-      final Result result) {
-    PeerConnection peerConnection = getPeerConnection(id);
-
-    if (peerConnection != null) {
-      peerConnection.createOffer(new SdpObserver() {
-        @Override
-        public void onCreateFailure(String s) {
-          resultError("peerConnectionCreateOffer", "WEBRTC_CREATE_OFFER_ERROR: " + s, result);
-      }
-
-        @Override
-        public void onCreateSuccess(final SessionDescription sdp) {
-          ConstraintsMap params = new ConstraintsMap();
-          params.putString("sdp", sdp.description);
-          params.putString("type", sdp.type.canonicalForm());
-          result.success(params.toMap());
+    public void peerConnectionSetConfiguration(ConstraintsMap configuration,
+                                               PeerConnection peerConnection) {
+        if (peerConnection == null) {
+            Log.d(TAG, "peerConnectionSetConfiguration() peerConnection is null");
+            return;
         }
+        peerConnection.setConfiguration(parseRTCConfiguration(configuration));
+    }
 
-        @Override
-        public void onSetFailure(String s) {
+    public void peerConnectionAddStream(final String streamId, final String id, Result result) {
+        MediaStream mediaStream = localStreams.get(streamId);
+        if (mediaStream == null) {
+            Log.d(TAG, "peerConnectionAddStream() mediaStream is null");
+            return;
         }
-
-        @Override
-        public void onSetSuccess() {
+        PeerConnection peerConnection = getPeerConnection(id);
+        if (peerConnection != null) {
+            boolean res = peerConnection.addStream(mediaStream);
+            Log.d(TAG, "addStream" + result);
+            result.success(res);
+        } else {
+            resultError("peerConnectionAddStream", "peerConnection is null", result);
         }
-      }, parseMediaConstraints(constraints));
-    } else {
-      resultError("peerConnectionCreateOffer", "WEBRTC_CREATE_OFFER_ERROR", result);
     }
-  }
 
-  public void peerConnectionCreateAnswer(
-      String id,
-      ConstraintsMap constraints,
-      final Result result) {
-    PeerConnection peerConnection = getPeerConnection(id);
-
-    if (peerConnection != null) {
-      peerConnection.createAnswer(new SdpObserver() {
-        @Override
-        public void onCreateFailure(String s) {
-          resultError("peerConnectionCreateAnswer", "WEBRTC_CREATE_ANSWER_ERROR: " + s, result);
+    public void peerConnectionRemoveStream(final String streamId, final String id, Result result) {
+        MediaStream mediaStream = localStreams.get(streamId);
+        if (mediaStream == null) {
+            Log.d(TAG, "peerConnectionRemoveStream() mediaStream is null");
+            return;
         }
-
-        @Override
-        public void onCreateSuccess(final SessionDescription sdp) {
-          ConstraintsMap params = new ConstraintsMap();
-          params.putString("sdp", sdp.description);
-          params.putString("type", sdp.type.canonicalForm());
-          result.success(params.toMap());
+        PeerConnection peerConnection = getPeerConnection(id);
+        if (peerConnection != null) {
+            peerConnection.removeStream(mediaStream);
+            result.success(null);
+        } else {
+            resultError("peerConnectionRemoveStream", "peerConnection is null", result);
         }
+    }
 
-        @Override
-        public void onSetFailure(String s) {
+    public void peerConnectionCreateOffer(
+            String id,
+            ConstraintsMap constraints,
+            final Result result) {
+        PeerConnection peerConnection = getPeerConnection(id);
+
+        if (peerConnection != null) {
+            peerConnection.createOffer(new SdpObserver() {
+                @Override
+                public void onCreateFailure(String s) {
+                    resultError("peerConnectionCreateOffer", "WEBRTC_CREATE_OFFER_ERROR: " + s, result);
+                }
+
+                @Override
+                public void onCreateSuccess(final SessionDescription sdp) {
+                    ConstraintsMap params = new ConstraintsMap();
+                    params.putString("sdp", sdp.description);
+                    params.putString("type", sdp.type.canonicalForm());
+                    result.success(params.toMap());
+                }
+
+                @Override
+                public void onSetFailure(String s) {
+                }
+
+                @Override
+                public void onSetSuccess() {
+                }
+            }, parseMediaConstraints(constraints));
+        } else {
+            resultError("peerConnectionCreateOffer", "WEBRTC_CREATE_OFFER_ERROR", result);
         }
+    }
 
-        @Override
-        public void onSetSuccess() {
+    public void peerConnectionCreateAnswer(
+            String id,
+            ConstraintsMap constraints,
+            final Result result) {
+        PeerConnection peerConnection = getPeerConnection(id);
+
+        if (peerConnection != null) {
+            peerConnection.createAnswer(new SdpObserver() {
+                @Override
+                public void onCreateFailure(String s) {
+                    resultError("peerConnectionCreateAnswer", "WEBRTC_CREATE_ANSWER_ERROR: " + s, result);
+                }
+
+                @Override
+                public void onCreateSuccess(final SessionDescription sdp) {
+                    ConstraintsMap params = new ConstraintsMap();
+                    params.putString("sdp", sdp.description);
+                    params.putString("type", sdp.type.canonicalForm());
+                    result.success(params.toMap());
+                }
+
+                @Override
+                public void onSetFailure(String s) {
+                }
+
+                @Override
+                public void onSetSuccess() {
+                }
+            }, parseMediaConstraints(constraints));
+        } else {
+            resultError("peerConnectionCreateAnswer", "peerConnection is null", result);
         }
-      }, parseMediaConstraints(constraints));
-    } else {
-      resultError("peerConnectionCreateAnswer", "peerConnection is null", result);
     }
-  }
 
-  public void peerConnectionSetLocalDescription(ConstraintsMap sdpMap, final String id,
-      final Result result) {
-    PeerConnection peerConnection = getPeerConnection(id);
-    if (peerConnection != null) {
-      SessionDescription sdp = new SessionDescription(
-          Type.fromCanonicalForm(sdpMap.getString("type")),
-          sdpMap.getString("sdp")
-      );
+    public void peerConnectionSetLocalDescription(ConstraintsMap sdpMap, final String id,
+                                                  final Result result) {
+        PeerConnection peerConnection = getPeerConnection(id);
+        if (peerConnection != null) {
+            SessionDescription sdp = new SessionDescription(
+                    Type.fromCanonicalForm(sdpMap.getString("type")),
+                    sdpMap.getString("sdp")
+            );
 
-      peerConnection.setLocalDescription(new SdpObserver() {
-        @Override
-        public void onCreateSuccess(final SessionDescription sdp) {
+            peerConnection.setLocalDescription(new SdpObserver() {
+                @Override
+                public void onCreateSuccess(final SessionDescription sdp) {
+                }
+
+                @Override
+                public void onSetSuccess() {
+                    result.success(null);
+                }
+
+                @Override
+                public void onCreateFailure(String s) {
+                }
+
+                @Override
+                public void onSetFailure(String s) {
+                    resultError("peerConnectionSetLocalDescription", "WEBRTC_SET_LOCAL_DESCRIPTION_ERROR: " + s, result);
+                }
+            }, sdp);
+        } else {
+            resultError("peerConnectionSetLocalDescription", "WEBRTC_SET_LOCAL_DESCRIPTION_ERROR: peerConnection is null", result);
         }
+    }
 
-        @Override
-        public void onSetSuccess() {
-          result.success(null);
+    public void peerConnectionSetRemoteDescription(final ConstraintsMap sdpMap, final String id,
+                                                   final Result result) {
+        PeerConnection peerConnection = getPeerConnection(id);
+        if (peerConnection != null) {
+            SessionDescription sdp = new SessionDescription(
+                    Type.fromCanonicalForm(sdpMap.getString("type")),
+                    sdpMap.getString("sdp")
+            );
+
+            peerConnection.setRemoteDescription(new SdpObserver() {
+                @Override
+                public void onCreateSuccess(final SessionDescription sdp) {
+                }
+
+                @Override
+                public void onSetSuccess() {
+                    result.success(null);
+                }
+
+                @Override
+                public void onCreateFailure(String s) {
+                }
+
+                @Override
+                public void onSetFailure(String s) {
+                    resultError("peerConnectionSetRemoteDescription", "WEBRTC_SET_REMOTE_DESCRIPTION_ERROR: " + s, result);
+                }
+            }, sdp);
+        } else {
+            resultError("peerConnectionSetRemoteDescription", "WEBRTC_SET_REMOTE_DESCRIPTION_ERROR: peerConnection is null", result);
         }
+    }
 
-        @Override
-        public void onCreateFailure(String s) {
+    public void peerConnectionAddICECandidate(ConstraintsMap candidateMap, final String id,
+                                              final Result result) {
+        boolean res = false;
+        PeerConnection peerConnection = getPeerConnection(id);
+        if (peerConnection != null) {
+            IceCandidate candidate = new IceCandidate(
+                    candidateMap.getString("sdpMid"),
+                    candidateMap.getInt("sdpMLineIndex"),
+                    candidateMap.getString("candidate")
+            );
+            res = peerConnection.addIceCandidate(candidate);
+        } else {
+            resultError("peerConnectionAddICECandidate", "peerConnection is null", result);
         }
+        result.success(res);
+    }
 
-        @Override
-        public void onSetFailure(String s) {
-          resultError("peerConnectionSetLocalDescription", "WEBRTC_SET_LOCAL_DESCRIPTION_ERROR: " + s, result);
+    public void peerConnectionGetStats(String trackId, String id, final Result result) {
+        PeerConnectionObserver pco = mPeerConnectionObservers.get(id);
+        if (pco == null || pco.getPeerConnection() == null) {
+            resultError("peerConnectionGetStats", "peerConnection is null", result);
+        } else {
+            pco.getStats(trackId, result);
         }
-      }, sdp);
-    } else {
-      resultError("peerConnectionSetLocalDescription", "WEBRTC_SET_LOCAL_DESCRIPTION_ERROR: peerConnection is null", result);
     }
-  }
 
-  public void peerConnectionSetRemoteDescription(final ConstraintsMap sdpMap, final String id,
-      final Result result) {
-    PeerConnection peerConnection = getPeerConnection(id);
-    if (peerConnection != null) {
-      SessionDescription sdp = new SessionDescription(
-          Type.fromCanonicalForm(sdpMap.getString("type")),
-          sdpMap.getString("sdp")
-      );
-
-      peerConnection.setRemoteDescription(new SdpObserver() {
-        @Override
-        public void onCreateSuccess(final SessionDescription sdp) {
+    public void peerConnectionClose(final String id) {
+        PeerConnectionObserver pco = mPeerConnectionObservers.get(id);
+        if (pco == null || pco.getPeerConnection() == null) {
+            Log.d(TAG, "peerConnectionClose() peerConnection is null");
+        } else {
+            pco.close();
         }
+    }
 
-        @Override
-        public void onSetSuccess() {
-          result.success(null);
+    public void peerConnectionDispose(final String id) {
+        PeerConnectionObserver pco = mPeerConnectionObservers.get(id);
+        if (pco == null || pco.getPeerConnection() == null) {
+            Log.d(TAG, "peerConnectionDispose() peerConnection is null");
+        } else {
+            pco.dispose();
+            mPeerConnectionObservers.remove(id);
         }
-
-        @Override
-        public void onCreateFailure(String s) {
+        if (mPeerConnectionObservers.size() == 0) {
+            audioManager.onAudioManagerRequested(false);
         }
+    }
 
-        @Override
-        public void onSetFailure(String s) {
-          resultError("peerConnectionSetRemoteDescription", "WEBRTC_SET_REMOTE_DESCRIPTION_ERROR: " + s, result);
+    public void mediaStreamRelease(final String id) {
+        MediaStream mediaStream = localStreams.get(id);
+        if (mediaStream != null) {
+            for (VideoTrack track : mediaStream.videoTracks) {
+                localTracks.remove(track.id());
+                getUserMediaImpl.removeVideoCapturer(track.id());
+            }
+            for (AudioTrack track : mediaStream.audioTracks) {
+                localTracks.remove(track.id());
+            }
+            localStreams.remove(id);
+        } else {
+            Log.d(TAG, "mediaStreamRelease() mediaStream is null");
         }
-      }, sdp);
-    } else {
-      resultError("peerConnectionSetRemoteDescription", "WEBRTC_SET_REMOTE_DESCRIPTION_ERROR: peerConnection is null", result);
     }
-  }
 
-  public void peerConnectionAddICECandidate(ConstraintsMap candidateMap, final String id,
-      final Result result) {
-    boolean res = false;
-    PeerConnection peerConnection = getPeerConnection(id);
-    if (peerConnection != null) {
-      IceCandidate candidate = new IceCandidate(
-          candidateMap.getString("sdpMid"),
-          candidateMap.getInt("sdpMLineIndex"),
-          candidateMap.getString("candidate")
-      );
-      res = peerConnection.addIceCandidate(candidate);
-    } else {
-      resultError("peerConnectionAddICECandidate", "peerConnection is null", result);
+    public void createDataChannel(final String peerConnectionId, String label, ConstraintsMap config,
+                                  Result result) {
+        // Forward to PeerConnectionObserver which deals with DataChannels
+        // because DataChannel is owned by PeerConnection.
+        PeerConnectionObserver pco
+                = mPeerConnectionObservers.get(peerConnectionId);
+        if (pco == null || pco.getPeerConnection() == null) {
+            Log.d(TAG, "createDataChannel() peerConnection is null");
+        } else {
+            pco.createDataChannel(label, config, result);
+        }
     }
-    result.success(res);
-  }
 
-  public void peerConnectionGetStats(String trackId, String id, final Result result) {
-    PeerConnectionObserver pco = mPeerConnectionObservers.get(id);
-    if (pco == null || pco.getPeerConnection() == null) {
-      resultError("peerConnectionGetStats", "peerConnection is null", result);
-    } else {
-      pco.getStats(trackId, result);
+    public void dataChannelSend(String peerConnectionId, int dataChannelId, ByteBuffer bytebuffer,
+                                Boolean isBinary) {
+        // Forward to PeerConnectionObserver which deals with DataChannels
+        // because DataChannel is owned by PeerConnection.
+        PeerConnectionObserver pco
+                = mPeerConnectionObservers.get(peerConnectionId);
+        if (pco == null || pco.getPeerConnection() == null) {
+            Log.d(TAG, "dataChannelSend() peerConnection is null");
+        } else {
+            pco.dataChannelSend(dataChannelId, bytebuffer, isBinary);
+        }
     }
-  }
 
-  public void peerConnectionClose(final String id) {
-    PeerConnectionObserver pco = mPeerConnectionObservers.get(id);
-    if (pco == null || pco.getPeerConnection() == null) {
-      Log.d(TAG, "peerConnectionClose() peerConnection is null");
-    } else {
-      pco.close();
+    public void dataChannelClose(String peerConnectionId, int dataChannelId) {
+        // Forward to PeerConnectionObserver which deals with DataChannels
+        // because DataChannel is owned by PeerConnection.
+        PeerConnectionObserver pco
+                = mPeerConnectionObservers.get(peerConnectionId);
+        if (pco == null || pco.getPeerConnection() == null) {
+            Log.d(TAG, "dataChannelClose() peerConnection is null");
+        } else {
+            pco.dataChannelClose(dataChannelId);
+        }
     }
-  }
 
-  public void peerConnectionDispose(final String id) {
-    PeerConnectionObserver pco = mPeerConnectionObservers.get(id);
-    if (pco == null || pco.getPeerConnection() == null) {
-      Log.d(TAG, "peerConnectionDispose() peerConnection is null");
-    } else {
-      pco.dispose();
-      mPeerConnectionObservers.remove(id);
+    public void setActivity(Activity activity) {
+        this.activity = activity;
     }
-    if (mPeerConnectionObservers.size() == 0) {
-      audioManager.onAudioManagerRequested(false);
+
+    public void addTrack(String peerConnectionId, String trackId, List<String> streamIds, Result result) {
+        PeerConnectionObserver pco = mPeerConnectionObservers.get(peerConnectionId);
+        MediaStreamTrack track = localTracks.get(trackId);
+        if (track == null) {
+            resultError("addTrack", "track is null", result);
+            return;
+        }
+        if (pco == null || pco.getPeerConnection() == null) {
+            resultError("addTrack", "peerConnection is null", result);
+        } else {
+            pco.addTrack(track, streamIds, result);
+        }
     }
-  }
 
-  public void mediaStreamRelease(final String id) {
-    MediaStream mediaStream = localStreams.get(id);
-    if (mediaStream != null) {
-      for (VideoTrack track : mediaStream.videoTracks) {
-        localTracks.remove(track.id());
-        getUserMediaImpl.removeVideoCapturer(track.id());
-      }
-      for (AudioTrack track : mediaStream.audioTracks) {
-        localTracks.remove(track.id());
-      }
-      localStreams.remove(id);
-    } else {
-      Log.d(TAG, "mediaStreamRelease() mediaStream is null");
+    public void removeTrack(String peerConnectionId, String senderId, Result result) {
+        PeerConnectionObserver pco = mPeerConnectionObservers.get(peerConnectionId);
+        if (pco == null || pco.getPeerConnection() == null) {
+            resultError("removeTrack", "peerConnection is null", result);
+        } else {
+            pco.removeTrack(senderId, result);
+        }
     }
-  }
 
-  public void createDataChannel(final String peerConnectionId, String label, ConstraintsMap config,
-      Result result) {
-    // Forward to PeerConnectionObserver which deals with DataChannels
-    // because DataChannel is owned by PeerConnection.
-    PeerConnectionObserver pco
-        = mPeerConnectionObservers.get(peerConnectionId);
-    if (pco == null || pco.getPeerConnection() == null) {
-      Log.d(TAG, "createDataChannel() peerConnection is null");
-    } else {
-      pco.createDataChannel(label, config, result);
+    public void addTransceiver(String peerConnectionId, String trackId, Map<String, Object> transceiverInit,
+                               Result result) {
+        PeerConnectionObserver pco = mPeerConnectionObservers.get(peerConnectionId);
+        MediaStreamTrack track = localTracks.get(trackId);
+        if (track == null) {
+            resultError("addTransceiver", "track is null", result);
+            return;
+        }
+        if (pco == null || pco.getPeerConnection() == null) {
+            resultError("addTransceiver", "peerConnection is null", result);
+        } else {
+            pco.addTransceiver(track, transceiverInit, result);
+        }
     }
-  }
 
-  public void dataChannelSend(String peerConnectionId, int dataChannelId, ByteBuffer bytebuffer,
-      Boolean isBinary) {
-    // Forward to PeerConnectionObserver which deals with DataChannels
-    // because DataChannel is owned by PeerConnection.
-    PeerConnectionObserver pco
-        = mPeerConnectionObservers.get(peerConnectionId);
-    if (pco == null || pco.getPeerConnection() == null) {
-      Log.d(TAG, "dataChannelSend() peerConnection is null");
-    } else {
-      pco.dataChannelSend(dataChannelId, bytebuffer, isBinary);
+    public void addTransceiverOfType(String peerConnectionId, String mediaType, Map<String, Object> transceiverInit,
+                                     Result result) {
+        PeerConnectionObserver pco = mPeerConnectionObservers.get(peerConnectionId);
+        if (pco == null || pco.getPeerConnection() == null) {
+            resultError("addTransceiverOfType", "peerConnection is null", result);
+        } else {
+            pco.addTransceiverOfType(mediaType, transceiverInit, result);
+        }
     }
-  }
 
-  public void dataChannelClose(String peerConnectionId, int dataChannelId) {
-    // Forward to PeerConnectionObserver which deals with DataChannels
-    // because DataChannel is owned by PeerConnection.
-    PeerConnectionObserver pco
-        = mPeerConnectionObservers.get(peerConnectionId);
-    if (pco == null || pco.getPeerConnection() == null) {
-      Log.d(TAG, "dataChannelClose() peerConnection is null");
-    } else {
-      pco.dataChannelClose(dataChannelId);
+    public void rtpTransceiverSetDirection(String peerConnectionId, String direction, String transceiverId, Result result) {
+        PeerConnectionObserver pco = mPeerConnectionObservers.get(peerConnectionId);
+        if (pco == null || pco.getPeerConnection() == null) {
+            resultError("rtpTransceiverSetDirection", "peerConnection is null", result);
+        } else {
+            pco.rtpTransceiverSetDirection(direction, transceiverId, result);
+        }
     }
-  }
 
-  public void setActivity(Activity activity) {
-    this.activity = activity;
-  }
-
-  public void addTrack(String peerConnectionId, String trackId, List<String> streamIds, Result result){
-      PeerConnectionObserver pco = mPeerConnectionObservers.get(peerConnectionId);
-      MediaStreamTrack track = localTracks.get(trackId);
-      if (track == null) {
-        resultError("addTrack", "track is null", result);
-        return;
-      }
-      if (pco == null || pco.getPeerConnection() == null) {
-        resultError("addTrack", "peerConnection is null", result);
-      } else {
-        pco.addTrack(track, streamIds, result);
-      }
-  }
-
-  public void removeTrack(String peerConnectionId, String senderId, Result result) {
-      PeerConnectionObserver pco = mPeerConnectionObservers.get(peerConnectionId);
-      if (pco == null || pco.getPeerConnection() == null) {
-        resultError("removeTrack", "peerConnection is null", result);
-      } else {
-          pco.removeTrack(senderId, result);
-      }
-  }
-
-  public void addTransceiver(String peerConnectionId, String trackId, Map<String, Object> transceiverInit,
-          Result result) {
-      PeerConnectionObserver pco = mPeerConnectionObservers.get(peerConnectionId);
-      MediaStreamTrack track = localTracks.get(trackId);
-      if (track == null) {
-        resultError("addTransceiver", "track is null", result);
-          return;
-      }
-      if (pco == null || pco.getPeerConnection() == null) {
-        resultError("addTransceiver", "peerConnection is null", result);
-      } else {
-          pco.addTransceiver(track, transceiverInit, result);
-      }
-  }
-
-  public void addTransceiverOfType(String peerConnectionId, String mediaType, Map<String, Object> transceiverInit,
-          Result result) {
-    PeerConnectionObserver pco = mPeerConnectionObservers.get(peerConnectionId);
-    if (pco == null || pco.getPeerConnection() == null) {
-      resultError("addTransceiverOfType", "peerConnection is null", result);
-    } else {
-      pco.addTransceiverOfType(mediaType, transceiverInit, result);
+    public void rtpTransceiverGetCurrentDirection(String peerConnectionId, String transceiverId, Result result) {
+        PeerConnectionObserver pco = mPeerConnectionObservers.get(peerConnectionId);
+        if (pco == null || pco.getPeerConnection() == null) {
+            resultError("rtpTransceiverSetDirection", "peerConnection is null", result);
+        } else {
+            pco.rtpTransceiverGetCurrentDirection(transceiverId, result);
+        }
     }
-  }
 
-  public void rtpTransceiverSetDirection(String peerConnectionId, String direction, String transceiverId, Result result) {
-    PeerConnectionObserver pco = mPeerConnectionObservers.get(peerConnectionId);
-    if (pco == null || pco.getPeerConnection() == null) {
-      resultError("rtpTransceiverSetDirection", "peerConnection is null", result);
-    } else {
-      pco.rtpTransceiverSetDirection(direction, transceiverId, result);
+    public void rtpTransceiverStop(String peerConnectionId, String transceiverId, Result result) {
+        PeerConnectionObserver pco = mPeerConnectionObservers.get(peerConnectionId);
+        if (pco == null || pco.getPeerConnection() == null) {
+            resultError("rtpTransceiverStop", "peerConnection is null", result);
+        } else {
+            pco.rtpTransceiverStop(transceiverId, result);
+        }
     }
-  }
 
-  public void rtpTransceiverGetCurrentDirection(String peerConnectionId, String transceiverId, Result result) {
-    PeerConnectionObserver pco = mPeerConnectionObservers.get(peerConnectionId);
-    if (pco == null || pco.getPeerConnection() == null) {
-      resultError("rtpTransceiverSetDirection", "peerConnection is null", result);
-    } else {
-      pco.rtpTransceiverGetCurrentDirection(transceiverId, result);
+    public void rtpSenderSetParameters(String peerConnectionId, String rtpSenderId, Map<String, Object> parameters, Result result) {
+        PeerConnectionObserver pco = mPeerConnectionObservers.get(peerConnectionId);
+        if (pco == null || pco.getPeerConnection() == null) {
+            resultError("rtpSenderSetParameters", "peerConnection is null", result);
+        } else {
+            pco.rtpSenderSetParameters(rtpSenderId, parameters, result);
+        }
     }
-  }
 
-  public void rtpTransceiverStop(String peerConnectionId, String transceiverId, Result result) {
-    PeerConnectionObserver pco = mPeerConnectionObservers.get(peerConnectionId);
-    if (pco == null || pco.getPeerConnection() == null) {
-      resultError("rtpTransceiverStop", "peerConnection is null", result);
-    } else {
-      pco.rtpTransceiverStop(transceiverId, result);
+    public void rtpSenderDispose(String peerConnectionId, String rtpSenderId, Result result) {
+        PeerConnectionObserver pco = mPeerConnectionObservers.get(peerConnectionId);
+        if (pco == null || pco.getPeerConnection() == null) {
+            resultError("rtpSenderDispose", "peerConnection is null", result);
+        } else {
+            pco.rtpSenderDispose(rtpSenderId, result);
+        }
     }
-  }
 
-  public void rtpSenderSetParameters(String peerConnectionId, String rtpSenderId, Map<String, Object> parameters, Result result) {
-    PeerConnectionObserver pco = mPeerConnectionObservers.get(peerConnectionId);
-    if (pco == null || pco.getPeerConnection() == null) {
-      resultError("rtpSenderSetParameters", "peerConnection is null", result);
-    } else {
-      pco.rtpSenderSetParameters(rtpSenderId, parameters, result);
+    public void getSenders(String peerConnectionId, Result result) {
+        PeerConnectionObserver pco = mPeerConnectionObservers.get(peerConnectionId);
+        if (pco == null || pco.getPeerConnection() == null) {
+            resultError("getSenders", "peerConnection is null", result);
+        } else {
+            pco.getSenders(result);
+        }
     }
-  }
 
-  public void rtpSenderDispose(String peerConnectionId, String rtpSenderId, Result result) {
-    PeerConnectionObserver pco = mPeerConnectionObservers.get(peerConnectionId);
-    if (pco == null || pco.getPeerConnection() == null) {
-      resultError("rtpSenderDispose", "peerConnection is null", result);
-    } else {
-      pco.rtpSenderDispose(rtpSenderId, result);
+    public void getReceivers(String peerConnectionId, Result result) {
+        PeerConnectionObserver pco = mPeerConnectionObservers.get(peerConnectionId);
+        if (pco == null || pco.getPeerConnection() == null) {
+            resultError("getReceivers", "peerConnection is null", result);
+        } else {
+            pco.getReceivers(result);
+        }
     }
-  }
 
-  public void getSenders(String peerConnectionId, Result result) {
-    PeerConnectionObserver pco = mPeerConnectionObservers.get(peerConnectionId);
-    if (pco == null || pco.getPeerConnection() == null) {
-      resultError("getSenders", "peerConnection is null", result);
-    } else {
-      pco.getSenders(result);
+    public void getTransceivers(String peerConnectionId, Result result) {
+        PeerConnectionObserver pco = mPeerConnectionObservers.get(peerConnectionId);
+        if (pco == null || pco.getPeerConnection() == null) {
+            resultError("getTransceivers", "peerConnection is null", result);
+        } else {
+            pco.getTransceivers(result);
+        }
     }
-  }
 
-  public void getReceivers(String peerConnectionId, Result result) {
-    PeerConnectionObserver pco = mPeerConnectionObservers.get(peerConnectionId);
-    if (pco == null || pco.getPeerConnection() == null) {
-      resultError("getReceivers", "peerConnection is null", result);
-    } else {
-      pco.getReceivers(result);
+    public void rtpSenderSetTrack(String peerConnectionId, String rtpSenderId, String trackId, boolean replace, Result result) {
+        PeerConnectionObserver pco = mPeerConnectionObservers.get(peerConnectionId);
+        if (pco == null || pco.getPeerConnection() == null) {
+            resultError("rtpSenderSetTrack", "peerConnection is null", result);
+        } else {
+            MediaStreamTrack track = localTracks.get(trackId);
+            if (track == null) {
+                resultError("rtpSenderSetTrack", "track is null", result);
+                return;
+            }
+            pco.rtpSenderSetTrack(rtpSenderId, track, result, replace);
+        }
     }
-  }
 
-  public void getTransceivers(String peerConnectionId, Result result) {
-    PeerConnectionObserver pco = mPeerConnectionObservers.get(peerConnectionId);
-    if (pco == null || pco.getPeerConnection() == null) {
-      resultError("getTransceivers", "peerConnection is null", result);
-    } else {
-      pco.getTransceivers(result);
-    }
-  }
 
-  public void rtpSenderSetTrack(String peerConnectionId, String rtpSenderId, String trackId, boolean replace,  Result result) {
-    PeerConnectionObserver pco = mPeerConnectionObservers.get(peerConnectionId);
-    if (pco == null || pco.getPeerConnection() == null) {
-      resultError("rtpSenderSetTrack", "peerConnection is null", result);
-    } else {
-      MediaStreamTrack track = localTracks.get(trackId);
-      if (track == null) {
-        resultError("rtpSenderSetTrack", "track is null", result);
-        return;
-      }
-      pco.rtpSenderSetTrack(rtpSenderId, track, result, replace);
+    public void reStartCamera() {
+        if (null == getUserMediaImpl) {
+            return;
+        }
+        getUserMediaImpl.reStartCamera(new GetUserMediaImpl.IsCameraEnabled() {
+            @Override
+            public boolean isEnabled(String id) {
+                if (!localTracks.containsKey(id)) {
+                    return false;
+                }
+                return localTracks.get(id).enabled();
+            }
+        });
     }
-  }
 }

--- a/example/lib/src/get_user_media_sample.dart
+++ b/example/lib/src/get_user_media_sample.dart
@@ -21,6 +21,7 @@ class _GetUserMediaSampleState extends State<GetUserMediaSample> {
   bool _inCalling = false;
   bool _isTorchOn = false;
   MediaRecorder? _mediaRecorder;
+
   bool get _isRec => _mediaRecorder != null;
 
   List<MediaDeviceInfo>? _mediaDevicesList;
@@ -160,7 +161,19 @@ class _GetUserMediaSampleState extends State<GetUserMediaSample> {
     final videoTrack = _localStream!
         .getVideoTracks()
         .firstWhere((track) => track.kind == 'video');
-    await videoTrack.captureFrame(filePath);
+    final frame = await videoTrack.captureFrame();
+    await showDialog(
+        context: context,
+        builder: (context) => AlertDialog(
+              content:
+                  Image.memory(frame.asUint8List(), height: 720, width: 1280),
+              actions: <Widget>[
+                FlatButton(
+                  child: Text('OK'),
+                  onPressed: Navigator.of(context, rootNavigator: true).pop,
+                )
+              ],
+            ));
   }
 
   @override

--- a/example/lib/src/get_user_media_sample_web.dart
+++ b/example/lib/src/get_user_media_sample_web.dart
@@ -122,7 +122,7 @@ class _GetUserMediaSampleState extends State<GetUserMediaSample> {
     await showDialog(
         context: context,
         builder: (context) => AlertDialog(
-              content: Image.network(frame, height: 720, width: 1280),
+              content: Image.memory(frame.asUint8List(), height: 720, width: 1280),
               actions: <Widget>[
                 TextButton(
                   onPressed: Navigator.of(context, rootNavigator: true).pop,

--- a/lib/src/interface/media_stream.dart
+++ b/lib/src/interface/media_stream.dart
@@ -45,8 +45,13 @@ abstract class MediaStream {
   List<MediaStreamTrack> getVideoTracks();
 
   /// Returns either a [MediaStreamTrack] object from this stream's track set whose id is equal to trackId, or [StateError], if no such track exists.
-  MediaStreamTrack getTrackById(String trackId) {
-    return getTracks().firstWhere((element) => element.id == trackId);
+  MediaStreamTrack? getTrackById(String trackId) {
+    for (var item in getTracks()) {
+      if (item.id == trackId) {
+        return item;
+      }
+    }
+    return null;
   }
 
   /// Clones the given [MediaStream] and all its tracks.

--- a/lib/src/interface/media_stream_track.dart
+++ b/lib/src/interface/media_stream_track.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_webrtc/src/helper.dart';
+import 'dart:typed_data';
 
 typedef StreamTrackCallback = Function();
 
@@ -93,7 +94,7 @@ abstract class MediaStreamTrack {
     throw UnimplementedError();
   }
 
-  Future<dynamic> captureFrame([String? filePath]) {
+  Future<ByteBuffer> captureFrame() {
     throw UnimplementedError();
   }
 

--- a/lib/src/interface/rtc_peerconnection.dart
+++ b/lib/src/interface/rtc_peerconnection.dart
@@ -73,19 +73,21 @@ abstract class RTCPeerConnection {
 
   Future<void> removeStream(MediaStream stream);
 
-  Future<RTCSessionDescription> getLocalDescription();
+  Future<RTCSessionDescription?> getLocalDescription();
+
   Future<void> setLocalDescription(RTCSessionDescription description);
 
-  Future<RTCSessionDescription> getRemoteDescription();
+  Future<RTCSessionDescription?> getRemoteDescription();
+
   Future<void> setRemoteDescription(RTCSessionDescription description);
 
   Future<void> addCandidate(RTCIceCandidate candidate);
 
   Future<List<StatsReport>> getStats([MediaStreamTrack? track]);
 
-  List<MediaStream> getLocalStreams();
+  List<MediaStream?> getLocalStreams();
 
-  List<MediaStream> getRemoteStreams();
+  List<MediaStream?> getRemoteStreams();
 
   Future<RTCDataChannel> createDataChannel(
       String label, RTCDataChannelInit dataChannelDict);

--- a/lib/src/native/media_stream_track_impl.dart
+++ b/lib/src/native/media_stream_track_impl.dart
@@ -1,18 +1,21 @@
 import 'dart:async';
+import 'dart:io';
+import 'dart:typed_data';
 
-// import 'package:flutter_webrtc/flutter_webrtc.dart';
-
-import '../helper.dart';
+import 'package:flutter_webrtc/flutter_webrtc.dart';
+import 'package:path_provider/path_provider.dart';
 
 import '../interface/media_stream_track.dart';
 import 'utils.dart';
 
 class MediaStreamTrackNative extends MediaStreamTrack {
   MediaStreamTrackNative(this._trackId, this._label, this._kind, this._enabled);
+
   factory MediaStreamTrackNative.fromMap(Map<dynamic, dynamic> map) {
     return MediaStreamTrackNative(
         map['id'], map['label'], map['kind'], map['enabled']);
   }
+
   final _channel = WebRTC.methodChannel();
   final String _trackId;
   final String _label;
@@ -73,11 +76,17 @@ class MediaStreamTrackNative extends MediaStreamTrack {
   }
 
   @override
-  Future<dynamic> captureFrame([String? filePath]) {
-    return _channel.invokeMethod<void>(
+  Future<ByteBuffer> captureFrame() async {
+    var filePath = await getTemporaryDirectory();
+    await _channel.invokeMethod<void>(
       'captureFrame',
-      <String, dynamic>{'trackId': _trackId, 'path': filePath},
+      <String, dynamic>{
+        'trackId': _trackId,
+        'path': filePath.path + '/captureFrame.png'
+      },
     );
+    return File(filePath.path + '/captureFrame.png').readAsBytes().then((
+        value) => value.buffer);
   }
 
   @override

--- a/lib/src/native/rtc_peerconnection_impl.dart
+++ b/lib/src/native/rtc_peerconnection_impl.dart
@@ -67,9 +67,9 @@ class RTCPeerConnectionNative extends RTCPeerConnection {
   @override
   RTCPeerConnectionState? get connectionState => _connectionState;
 
-  Future<RTCSessionDescription> get localDescription => getLocalDescription();
+  Future<RTCSessionDescription?> get localDescription => getLocalDescription();
 
-  Future<RTCSessionDescription> get remoteDescription => getRemoteDescription();
+  Future<RTCSessionDescription?> get remoteDescription => getRemoteDescription();
 
   /*
    * PeerConnection event listener.
@@ -115,8 +115,13 @@ class RTCPeerConnectionNative extends RTCPeerConnection {
         break;
       case 'onRemoveStream':
         String streamId = map['streamId'];
-        var stream = _remoteStreams.firstWhere((it) => it.id == streamId);
-        onRemoveStream?.call(stream);
+
+        for(var item in _remoteStreams){
+          if(item.id == streamId){
+            onRemoveStream?.call(item);
+            break;
+          }
+        }
         _remoteStreams.removeWhere((it) => it.id == streamId);
         break;
       case 'onAddTrack':
@@ -148,11 +153,15 @@ class RTCPeerConnectionNative extends RTCPeerConnection {
         break;
       case 'onRemoveTrack':
         String streamId = map['streamId'];
-        var stream = _remoteStreams.firstWhere((it) => it.id == streamId);
-        Map<dynamic, dynamic> track = map['track'];
-        var oldTrack = MediaStreamTrackNative(
-            map['trackId'], track['label'], track['kind'], track['enabled']);
-        onRemoveTrack?.call(stream, oldTrack);
+        for(var item in _remoteStreams){
+          if(item.id == streamId){
+            Map<dynamic, dynamic> track = map['track'];
+            var oldTrack = MediaStreamTrackNative(
+                map['trackId'], track['label'], track['kind'], track['enabled']);
+            onRemoveTrack?.call(item, oldTrack);
+            break;
+          }
+        }
         break;
       case 'didOpenDataChannel':
         int dataChannelId = map['id'];
@@ -321,13 +330,16 @@ class RTCPeerConnectionNative extends RTCPeerConnection {
   }
 
   @override
-  Future<RTCSessionDescription> getLocalDescription() async {
+  Future<RTCSessionDescription?> getLocalDescription() async {
     try {
       final response =
           await WebRTC.invokeMethod('getLocalDescription', <String, dynamic>{
         'peerConnectionId': _peerConnectionId,
       });
 
+      if (null == response) {
+        return null;
+      }
       String sdp = response['sdp'];
       String type = response['type'];
       return RTCSessionDescription(sdp, type);
@@ -337,13 +349,16 @@ class RTCPeerConnectionNative extends RTCPeerConnection {
   }
 
   @override
-  Future<RTCSessionDescription> getRemoteDescription() async {
+  Future<RTCSessionDescription?> getRemoteDescription() async {
     try {
       final response =
           await WebRTC.invokeMethod('getRemoteDescription', <String, dynamic>{
         'peerConnectionId': _peerConnectionId,
       });
 
+      if (null == response) {
+        return null;
+      }
       String sdp = response['sdp'];
       String type = response['type'];
       return RTCSessionDescription(sdp, type);

--- a/lib/src/web/media_stream_track_impl.dart
+++ b/lib/src/web/media_stream_track_impl.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:html' as html;
 import 'dart:js_util' as js;
+import 'dart:typed_data';
 
 import '../interface/media_stream_track.dart';
 
@@ -58,7 +59,7 @@ class MediaStreamTrackWeb extends MediaStreamTrack {
   // }
 
   @override
-  Future<dynamic> captureFrame([String? filePath]) async {
+  Future<ByteBuffer> captureFrame() async {
     final imageCapture = html.ImageCapture(jsTrack);
     final bitmap = await imageCapture.grabFrame();
     final canvas = html.CanvasElement();
@@ -67,9 +68,10 @@ class MediaStreamTrackWeb extends MediaStreamTrack {
     final renderer =
         canvas.getContext('bitmaprenderer') as html.ImageBitmapRenderingContext;
     renderer.transferFromImageBitmap(bitmap);
-    final dataUrl = canvas.toDataUrl();
+    final blod = await canvas.toBlob();
+    var array = await js.promiseToFuture(js.callMethod(blod, 'arrayBuffer', []));
     bitmap.close();
-    return dataUrl;
+    return array;
   }
 
   @override

--- a/lib/src/web/rtc_peerconnection_impl.dart
+++ b/lib/src/web/rtc_peerconnection_impl.dart
@@ -323,8 +323,8 @@ class RTCPeerConnectionWeb extends RTCPeerConnection {
   @override
   Future<bool> removeTrack(RTCRtpSender sender) async {
     var nativeSender = sender as RTCRtpSenderWeb;
-    var nativeTrack = nativeSender.track as MediaStreamTrackWeb;
-    return jsutil.callMethod(_jsPc, 'removeTrack', [nativeTrack.jsTrack]);
+    // var nativeTrack = nativeSender.track as MediaStreamTrackWeb;
+    return jsutil.callMethod(_jsPc, 'removeTrack', [nativeSender.jsRtpSender]);
   }
 
   @override

--- a/lib/src/web/rtc_rtp_sender_impl.dart
+++ b/lib/src/web/rtc_rtp_sender_impl.dart
@@ -79,7 +79,12 @@ class RTCRtpSenderWeb extends RTCRtpSender {
   }
 
   @override
-  MediaStreamTrack get track => MediaStreamTrackWeb(_jsRtpSender.track!);
+  MediaStreamTrack? get track {
+    if (null != _jsRtpSender.track) {
+      return MediaStreamTrackWeb(_jsRtpSender.track!);
+    }
+    return null;
+  }
 
   @override
   String get senderId => jsutil.getProperty(_jsRtpSender, 'senderId');
@@ -93,4 +98,6 @@ class RTCRtpSenderWeb extends RTCRtpSender {
 
   @override
   Future<void> dispose() async {}
+
+  RtcRtpSender get jsRtpSender => _jsRtpSender;
 }

--- a/lib/src/web/rtc_video_renderer_impl.dart
+++ b/lib/src/web/rtc_video_renderer_impl.dart
@@ -33,24 +33,36 @@ const String _kDefaultErrorMessage =
     'No further diagnostic information can be determined or provided.';
 
 class RTCVideoRendererWeb extends VideoRenderer {
+  html.AudioElement? _audioElement;
+
   RTCVideoRendererWeb() : _textureId = _textureCounter++;
 
   static int _textureCounter = 1;
+
+  html.MediaStream? _videoStream;
+
+  html.MediaStream? _audioStream;
+
+  MediaStreamWeb? _srcObject;
+
   final int _textureId;
-  final html.VideoElement _videoElement = html.VideoElement()
-    ..autoplay = true
-    ..muted = false
-    ..controls = false
-    ..style.objectFit = 'contain'
-    ..style.border = 'none'
-    ..setAttribute('playsinline', 'true');
-  MediaStream? _srcObject;
+
+  bool _mirror = false;
+
   final _subscriptions = <StreamSubscription>[];
 
-  set objectFit(String fit) => _videoElement.style.objectFit = fit;
+  String _objectFit = 'contain';
 
-  set mirror(bool mirror) =>
-      _videoElement.style.transform = 'rotateY(${mirror ? "180" : "0"}deg)';
+  bool _muted = false;
+
+  set objectFit(String fit) =>
+      findHtmlView()?.style?.objectFit = _objectFit = fit;
+
+  bool get mirror => _mirror;
+
+  set mirror(bool mirror) {
+    _mirror = mirror;
+  }
 
   @override
   int get videoWidth => value.width.toInt();
@@ -62,91 +74,22 @@ class RTCVideoRendererWeb extends VideoRenderer {
   int get textureId => _textureId;
 
   @override
-  bool get muted => _videoElement.muted;
+  bool get muted => _muted;
 
   @override
-  set muted(bool mute) => _videoElement.muted = mute;
+  set muted(bool mute) => _audioElement?.muted = _muted = mute;
 
   @override
   bool get renderVideo => _srcObject != null;
 
-  @override
-  Future<void> initialize() async {
-    // _videoElement = html.VideoElement()
-    //   ..autoplay = true
-    //   ..muted = false
-    //   ..controls = false
-    //   ..style.objectFit = 'contain'
-    //   ..style.border = 'none'
-    //   ..setAttribute('playsinline', 'true');
-
-    // // Allows Safari iOS to play the video inline
-    // _videoElement.setAttribute('playsinline', 'true');
-
-    // ignore: undefined_prefixed_name
-    ui.platformViewRegistry.registerViewFactory(
-        'RTCVideoRenderer-$textureId', (int viewId) => _videoElement);
-
-    _subscriptions.add(_videoElement.onPause.listen((event) {
-      _videoElement.play();
-    }));
-
-    _subscriptions.add(
-      _videoElement.onCanPlay.listen(
-        (dynamic _) {
-          _updateAllValues();
-          //print('RTCVideoRenderer: videoElement.onCanPlay ${value.toString()}');
-        },
-      ),
-    );
-
-    _subscriptions.add(
-      _videoElement.onResize.listen(
-        (dynamic _) {
-          _updateAllValues();
-          onResize?.call();
-          //print('RTCVideoRenderer: videoElement.onResize ${value.toString()}');
-        },
-      ),
-    );
-
-    // The error event fires when some form of error occurs while attempting to load or perform the media.
-    _subscriptions.add(
-      _videoElement.onError.listen(
-        (html.Event _) {
-          // The Event itself (_) doesn't contain info about the actual error.
-          // We need to look at the HTMLMediaElement.error.
-          // See: https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/error
-          var error = _videoElement.error;
-          print('RTCVideoRenderer: videoElement.onError, ${error.toString()}');
-          throw PlatformException(
-            code: _kErrorValueToErrorName[
-                    error?.code ?? html.MediaError.MEDIA_ERR_ABORTED] ??
-                '',
-            message:
-                error?.message != '' ? error?.message : _kDefaultErrorMessage,
-            details: _kErrorValueToErrorDescription[
-                error?.code ?? html.MediaError.MEDIA_ERR_ABORTED],
-          );
-        },
-      ),
-    );
-
-    _subscriptions.add(
-      _videoElement.onEnded.listen(
-        (dynamic _) {
-          //print('RTCVideoRenderer: videoElement.onEnded');
-        },
-      ),
-    );
-  }
-
   void _updateAllValues() {
+    var element = findHtmlView();
     value = value.copyWith(
-        rotation: 0,
-        width: _videoElement.videoWidth.toDouble(),
-        height: _videoElement.videoHeight.toDouble(),
-        renderVideo: renderVideo);
+      rotation: 0,
+      width: element?.videoWidth?.toDouble() ?? 0.0,
+      height: element?.videoHeight?.toDouble() ?? 0.0,
+      renderVideo: renderVideo,
+    );
   }
 
   @override
@@ -154,16 +97,68 @@ class RTCVideoRendererWeb extends VideoRenderer {
 
   @override
   set srcObject(MediaStream? stream) {
-    if (stream == null) {
-      _videoElement.srcObject = null;
-      _srcObject = null;
-      return;
+    _srcObject = stream as MediaStreamWeb;
+
+    if (null != _srcObject) {
+      if (stream.getVideoTracks().isNotEmpty) {
+        _videoStream = html.MediaStream();
+        for (var track in _srcObject!.jsStream.getVideoTracks()) {
+          _videoStream!.addTrack(track);
+        }
+      }
+      if (stream.getAudioTracks().isNotEmpty) {
+        _audioStream = html.MediaStream();
+        for (var track in _srcObject!.jsStream.getAudioTracks()) {
+          _audioStream!.addTrack(track);
+        }
+      }
+    } else {
+      _videoStream = null;
+      _audioStream = null;
     }
-    _srcObject = stream;
-    var jsStream = (stream as MediaStreamWeb).jsStream;
-    _videoElement.srcObject = jsStream;
-    _videoElement.muted = stream.ownerTag == 'local';
+
+    if (null != _audioStream) {
+      if (null == _audioElement) {
+        _audioElement = html.AudioElement()
+          ..id = 'audio_RTCVideoRenderer-$textureId'
+          ..muted = stream.ownerTag == 'local'
+          ..autoplay = true;
+        getAudioManageDiv().append(_audioElement!);
+      }
+      _audioElement?.srcObject = _audioStream;
+    }
+    findHtmlView()?.srcObject = _videoStream;
+
     value = value.copyWith(renderVideo: renderVideo);
+  }
+
+  html.DivElement getAudioManageDiv() {
+    var div = html.document.getElementById('html_webrtc_audio_manage_list');
+    if (null != div) {
+      return div as html.DivElement;
+    }
+    div = html.DivElement();
+    div.id = 'html_webrtc_audio_manage_list';
+    div.style.display = 'none';
+    html.document.body!.append(div);
+    return div as html.DivElement;
+  }
+
+  html.VideoElement? findHtmlView() {
+    var video =
+        html.document.getElementById('video_RTCVideoRenderer-$textureId');
+    if (null != video) {
+      return video as html.VideoElement;
+    }
+    final fltPv = html.document.getElementsByTagName('flt-platform-view');
+    if (fltPv.isEmpty) return null;
+    var child = (fltPv.first as html.Element).shadowRoot!.childNodes;
+    for (var item in child) {
+      if ((item as html.Element).id == 'video_RTCVideoRenderer-$textureId') {
+        return item as html.VideoElement;
+      }
+    }
+    return null;
   }
 
   @override
@@ -171,17 +166,20 @@ class RTCVideoRendererWeb extends VideoRenderer {
     await _srcObject?.dispose();
     _srcObject = null;
     _subscriptions.forEach((s) => s.cancel());
-    _videoElement.removeAttribute('src');
-    _videoElement.load();
+    var element = findHtmlView();
+    element?.removeAttribute('src');
+    element?.load();
+    getAudioManageDiv().remove();
     return super.dispose();
   }
 
   @override
   Future<bool> audioOutput(String deviceId) async {
     try {
-      if (jsutil.hasProperty(_videoElement, 'setSinkId')) {
+      var element = findHtmlView();
+      if (null != element && jsutil.hasProperty(element, 'setSinkId')) {
         await jsutil.promiseToFuture<void>(
-            jsutil.callMethod(_videoElement, 'setSinkId', [deviceId]));
+            jsutil.callMethod(element, 'setSinkId', [deviceId]));
 
         return true;
       }
@@ -189,5 +187,65 @@ class RTCVideoRendererWeb extends VideoRenderer {
       print('Unable to setSinkId: ${e.toString()}');
     }
     return false;
+  }
+
+  @override
+  Future<void> initialize() async {
+    var id = 'RTCVideoRenderer-$textureId';
+    // // ignore: undefined_prefixed_name
+    ui.platformViewRegistry.registerViewFactory(id, (int viewId) {
+      _subscriptions.forEach((s) => s.cancel());
+      _subscriptions.clear();
+
+      var element = html.VideoElement()
+        ..autoplay = true
+        ..muted = true
+        ..controls = false
+        ..style.objectFit = _objectFit
+        ..style.border = 'none'
+        ..srcObject = _videoStream
+        ..id = "video_$id"
+        ..setAttribute('playsinline', 'true');
+
+      _subscriptions.add(
+        element.onCanPlay.listen((dynamic _) {
+          _updateAllValues();
+          // print('RTCVideoRenderer: videoElement.onCanPlay ${value.toString()}');
+        }),
+      );
+
+      _subscriptions.add(
+        element.onResize.listen((dynamic _) {
+          _updateAllValues();
+          onResize?.call();
+          // print('RTCVideoRenderer: videoElement.onResize ${value.toString()}');
+        }),
+      );
+
+      // The error event fires when some form of error occurs while attempting to load or perform the media.
+      _subscriptions.add(
+        element.onError.listen((html.Event _) {
+          // The Event itself (_) doesn't contain info about the actual error.
+          // We need to look at the HTMLMediaElement.error.
+          // See: https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/error
+          var error = element.error;
+          print('RTCVideoRenderer: videoElement.onError, ${error.toString()}');
+          throw PlatformException(
+            code: _kErrorValueToErrorName[error!.code]!,
+            message:
+                error.message != '' ? error.message : _kDefaultErrorMessage,
+            details: _kErrorValueToErrorDescription[error.code],
+          );
+        }),
+      );
+
+      _subscriptions.add(
+        element.onEnded.listen((dynamic _) {
+          // print('RTCVideoRenderer: videoElement.onEnded');
+        }),
+      );
+
+      return element;
+    });
   }
 }

--- a/lib/src/web/rtc_video_view_impl.dart
+++ b/lib/src/web/rtc_video_view_impl.dart
@@ -1,3 +1,6 @@
+import 'dart:async';
+import 'dart:math';
+
 import 'package:flutter/material.dart';
 
 import '../interface/enums.dart';
@@ -17,44 +20,72 @@ class RTCVideoView extends StatefulWidget {
   final RTCVideoViewObjectFit objectFit;
   final bool mirror;
   final FilterQuality filterQuality;
+
   @override
   _RTCVideoViewState createState() => _RTCVideoViewState();
 }
 
 class _RTCVideoViewState extends State<RTCVideoView> {
   _RTCVideoViewState();
+
   RTCVideoRendererWeb get videoRenderer =>
       widget._renderer.delegate as RTCVideoRendererWeb;
+
   @override
   void initState() {
     super.initState();
-    widget._renderer.delegate.addListener(() {
-      if (mounted) setState(() {});
-    });
-  }
-
-  Widget buildVideoElementView(RTCVideoViewObjectFit objFit, bool mirror) {
-    videoRenderer.mirror = mirror;
+    widget._renderer.delegate.addListener(_onRendererListener);
+    videoRenderer.mirror = widget.mirror;
     videoRenderer.objectFit =
-        objFit == RTCVideoViewObjectFit.RTCVideoViewObjectFitContain
+        widget.objectFit == RTCVideoViewObjectFit.RTCVideoViewObjectFitContain
             ? 'contain'
             : 'cover';
-    return HtmlElementView(
-        viewType: 'RTCVideoRenderer-${videoRenderer.textureId}');
+  }
+
+  void _onRendererListener() {
+    if (mounted) setState(() {});
+  }
+
+  @override
+  void dispose() {
+    widget._renderer.delegate.removeListener(_onRendererListener);
+    super.dispose();
+  }
+
+  @override
+  void didUpdateWidget(RTCVideoView oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    Timer(
+        Duration(milliseconds: 10), () => videoRenderer.mirror = widget.mirror);
+    videoRenderer.objectFit =
+        widget.objectFit == RTCVideoViewObjectFit.RTCVideoViewObjectFitContain
+            ? 'contain'
+            : 'cover';
+  }
+
+  Widget buildVideoElementView() {
+    return Transform(
+      alignment: Alignment.center,
+      transform: Matrix4.rotationY(videoRenderer.mirror ? pi * -1 : 0),
+      child: HtmlElementView(
+          viewType: 'RTCVideoRenderer-${videoRenderer.textureId}'),
+    );
   }
 
   @override
   Widget build(BuildContext context) {
     return LayoutBuilder(
-        builder: (BuildContext context, BoxConstraints constraints) {
-      return Center(
+      builder: (BuildContext context, BoxConstraints constraints) {
+        return Center(
           child: Container(
-        width: constraints.maxWidth,
-        height: constraints.maxHeight,
-        child: widget._renderer.renderVideo
-            ? buildVideoElementView(widget.objectFit, widget.mirror)
-            : Container(),
-      ));
-    });
+            width: constraints.maxWidth,
+            height: constraints.maxHeight,
+            child: widget._renderer.renderVideo
+                ? buildVideoElementView()
+                : Container(),
+          ),
+        );
+      },
+    );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-
+  path_provider: ^2.0.1
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
1.修改 RTCPeerConnectionWeb.removeTrack BUG
2.修改 MediaStreamTrack.captureFrame返回数据为 ByteBuffer 以兼容web端
3.修改 MediaStream.getTrackById 函数没有找到track时报错的BUG
4.修改 RTCPeerConnection.getLocalDescription函数允许返回null
5.修改 RTCPeerConnection.getRemoteDescription函数允许返回null
6.修改 RTCPeerConnection.getLocalStreams函数允许返回null
7.修改 RTCPeerConnection.getRemoteStreams函数允许返回null
8.修改 RTCPeerConnectionNative 中 onRemoveStream 时未找到stream时报错的BUG
9.修改 RTCPeerConnectionNative 中 onRemoveTrack 时未找到stream时报错的BUG
10.修改RTCRtpSenderWeb.track 属性允许返回null
11.重写 RTCVideoRendererWeb 和 RTCVideoView Web，使视频和音频分开渲染成video和audio Html标签，解决隐藏视频时，不能播放声音的BUG(在大量视频场景).
12.Android端添加重新激活相机功能（当其APP抢占相机时，回到APP时重新激活相机）