### PR TITLE
[Android] Screen share orientation fix #495 .

### DIFF
--- a/android/src/main/java/com/cloudwebrtc/webrtc/GetUserMediaImpl.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/GetUserMediaImpl.java
@@ -60,7 +60,6 @@ import org.webrtc.MediaConstraints;
 import org.webrtc.MediaStream;
 import org.webrtc.MediaStreamTrack;
 import org.webrtc.PeerConnectionFactory;
-import org.webrtc.ScreenCapturerAndroid;
 import org.webrtc.SurfaceTextureHelper;
 import org.webrtc.VideoCapturer;
 import org.webrtc.VideoSource;
@@ -466,7 +465,7 @@ class GetUserMediaImpl {
                         MediaStreamTrack[] tracks = new MediaStreamTrack[1];
                         VideoCapturer videoCapturer = null;
                         videoCapturer =
-                                new ScreenCapturerAndroid(
+                                new OrientationAwareScreenCapturer(
                                         mediaProjectionData,
                                         new MediaProjection.Callback() {
                                             @Override
@@ -502,7 +501,7 @@ class GetUserMediaImpl {
                         info.capturer = videoCapturer;
 
                         videoCapturer.startCapture(info.width, info.height, info.fps);
-                        Log.d(TAG, "ScreenCapturerAndroid.startCapture: " + info.width + "x" + info.height + "@" + info.fps);
+                        Log.d(TAG, "OrientationAwareScreenCapturer.startCapture: " + info.width + "x" + info.height + "@" + info.fps);
 
                         String trackId = stateProvider.getNextTrackUUID();
                         mVideoCapturers.put(trackId, info);

--- a/android/src/main/java/com/cloudwebrtc/webrtc/OrientationAwareScreenCapturer.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/OrientationAwareScreenCapturer.java
@@ -1,0 +1,86 @@
+package com.cloudwebrtc.webrtc;
+
+import org.webrtc.ScreenCapturerAndroid;
+import org.webrtc.SurfaceTextureHelper;
+import org.webrtc.CapturerObserver;
+import org.webrtc.VideoFrame;
+
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.content.Intent;
+import android.media.projection.MediaProjection;
+import android.util.Log;
+import android.view.Surface;
+import android.view.WindowManager;
+
+
+/**
+ * An implementation of ScreenCapturerAndroid to capture the screen content while being aware of device orientation
+ */
+@TargetApi(21)
+public class OrientationAwareScreenCapturer
+        extends ScreenCapturerAndroid {
+    private Context applicationContext;
+    private WindowManager windowManager;
+    private int width;
+    private int height;
+    private boolean isPortrait;
+
+    /**
+     * Constructs a new Screen Capturer.
+     *
+     * @param mediaProjectionPermissionResultData the result data of MediaProjection permission
+     *                                            activity; the calling app must validate that result code is Activity.RESULT_OK before
+     *                                            calling this method.
+     * @param mediaProjectionCallback             MediaProjection callback to implement application specific
+     *                                            logic in events such as when the user revokes a previously granted capture permission.
+     **/
+    public OrientationAwareScreenCapturer(Intent mediaProjectionPermissionResultData,
+                                          MediaProjection.Callback mediaProjectionCallback) {
+        super(mediaProjectionPermissionResultData, mediaProjectionCallback);
+    }
+
+    @Override
+    public synchronized void initialize(SurfaceTextureHelper surfaceTextureHelper, Context applicationContext, CapturerObserver capturerObserver) {
+        super.initialize(surfaceTextureHelper, applicationContext, capturerObserver);
+        this.applicationContext = applicationContext;
+        Log.d("OrientationAwareSC", "OrientationAwareScreenCapturer: initialized and orientation isPortrait? " + this.isPortrait);
+    }
+
+    @Override
+    public synchronized void startCapture(int width, int height, int ignoredFramerate) {
+        this.windowManager = (WindowManager) applicationContext.getSystemService(
+                Context.WINDOW_SERVICE);
+        this.isPortrait = isDeviceOrientationPortrait();
+        if (this.isPortrait) {
+            this.width = width;
+            this.height = height;
+        } else {
+            this.height = width;
+            this.width = height;
+        }
+        super.startCapture(width, height, ignoredFramerate);
+    }
+
+    @Override
+    public void onFrame(VideoFrame frame) {
+        final boolean isOrientationPortrait = isDeviceOrientationPortrait();
+        if (isOrientationPortrait != this.isPortrait) {
+            this.isPortrait = isOrientationPortrait;
+
+            if (this.isPortrait) {
+                super.changeCaptureFormat(this.width, this.height, 15);
+            } else {
+                super.changeCaptureFormat(this.height, this.width, 15);
+            }
+        }
+        super.onFrame(frame);
+    }
+
+    private boolean isDeviceOrientationPortrait() {
+        final int surfaceRotation = windowManager.getDefaultDisplay().getRotation();
+
+        return surfaceRotation != Surface.ROTATION_90 && surfaceRotation != Surface.ROTATION_270;
+    }
+
+}


### PR DESCRIPTION
Added `OrientationAwareScreenCapturer` which extends from `ScreenCapturerAndroid` but checks orientation in the `onFrame` and calls `changeCaptureFormat` if orientation changes, I don't know if it's the best approach since we call `windowManager.getDefaultDisplay().getRotation()` with each frame being processed but it works perfectly when I tested it out.

This is a fix to issue #495 