### PR TITLE
[Android] falling back to the first available camera fix #580

### DIFF
--- a/android/src/main/java/com/cloudwebrtc/webrtc/GetUserMediaImpl.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/GetUserMediaImpl.java
@@ -279,7 +279,13 @@ class GetUserMediaImpl {
                 }
             }
         }
-        // should we fallback to available camera automatically?
+
+        // falling back to the first available camera
+        if (videoCapturer == null && deviceNames.length > 0){
+            videoCapturer = enumerator.createCapturer(deviceNames[0], new CameraEventsHandler());
+            Log.d(TAG, "Falling back to the first available camera");
+        }
+
         return videoCapturer;
     }
 


### PR DESCRIPTION
Added code to fall back to the first available camera in case the `createVideoCapturer` fails to find a suitable camera based on constraints (doesn't have a front/back camera) like an Android TV that will most likely have an external camera or any other type.