### PR TITLE
Fix application exit null-pointer exception

### DIFF
--- a/android/src/main/java/com/cloudwebrtc/webrtc/FlutterWebRTCPlugin.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/FlutterWebRTCPlugin.java
@@ -94,7 +94,9 @@ public class FlutterWebRTCPlugin implements FlutterPlugin, ActivityAware {
         methodCallHandler.setActivity(null);
         if (this.observer != null) {
             this.lifecycle.removeObserver(this.observer);
-            this.application.unregisterActivityLifecycleCallbacks(this.observer);
+            if (this.application!=null) {
+                this.application.unregisterActivityLifecycleCallbacks(this.observer);
+            }
         }
         this.lifecycle = null;
     }


### PR DESCRIPTION
When application exits, it throws an exception:
Exception 'java.lang.NullPointerException' occurred in thread 'main' at com.cloudwebrtc.webrtc.FlutterWebRTCPlugin.onDetachedFromActivity(FlutterWebRTCPlugin.java:97)

See also issue #578

Signed-off-by: Peter Antoniac <pan1nx+flutterwebrtc@gmail.com>