### PR TITLE
Add label getter to DataChannel Interface

### DIFF
--- a/lib/src/interface/rtc_data_channel.dart
+++ b/lib/src/interface/rtc_data_channel.dart
@@ -75,6 +75,9 @@ abstract class RTCDataChannel {
   /// Get current state.
   RTCDataChannelState? get state;
 
+  /// Get channel label
+  String? get label;
+
   /// Stream of state change events. Emits the new state on change.
   /// Closes when the [RTCDataChannel] is closed.
   late Stream<RTCDataChannelState> stateChangeStream;

--- a/lib/src/native/rtc_data_channel_impl.dart
+++ b/lib/src/native/rtc_data_channel_impl.dart
@@ -33,7 +33,8 @@ class RTCDataChannelNative extends RTCDataChannel {
   RTCDataChannelState? get state => _state;
 
   /// Get label.
-  String get label => _label;
+  @override
+  String? get label => _label;
 
   final _stateChangeController =
       StreamController<RTCDataChannelState>.broadcast(sync: true);

--- a/lib/src/web/rtc_data_channel_impl.dart
+++ b/lib/src/web/rtc_data_channel_impl.dart
@@ -32,6 +32,9 @@ class RTCDataChannelWeb extends RTCDataChannel {
   @override
   RTCDataChannelState get state => _state;
 
+  @override
+  String? get label => _jsDc.label;
+
   final _stateChangeController =
       StreamController<RTCDataChannelState>.broadcast(sync: true);
   final _messageController =


### PR DESCRIPTION
Adds a label getter to the DataChannel Interface and implements the label getter for the web implementation.

Closes #584 

