### PR TITLE
[Web] fix: exception raises at RTCPeerConnection and RTCRtpSender

### DIFF
--- a/lib/src/web/rtc_peerconnection_impl.dart
+++ b/lib/src/web/rtc_peerconnection_impl.dart
@@ -330,7 +330,8 @@ class RTCPeerConnectionWeb extends RTCPeerConnection {
   Future<bool> removeTrack(RTCRtpSender sender) async {
     var nativeSender = sender as RTCRtpSenderWeb;
     // var nativeTrack = nativeSender.track as MediaStreamTrackWeb;
-    return jsutil.callMethod(_jsPc, 'removeTrack', [nativeSender.jsRtpSender]);
+    jsutil.callMethod(_jsPc, 'removeTrack', [nativeSender.jsRtpSender]);
+    return Future<bool>.value(true);
   }
 
   @override

--- a/lib/src/web/rtc_rtp_sender_impl.dart
+++ b/lib/src/web/rtc_rtp_sender_impl.dart
@@ -59,8 +59,9 @@ class RTCRtpSenderWeb extends RTCRtpSender {
           'encodings',
           jsutil.jsify(
               parameters.encodings?.map((e) => e.toMap()).toList() ?? []));
-      return await jsutil.promiseToFuture<bool>(
+      await jsutil.promiseToFuture<void>(
           jsutil.callMethod(_jsRtpSender, 'setParameters', [oldParameters]));
+      return Future<bool>.value(true);
     } on PlatformException catch (e) {
       throw 'Unable to RTCRtpSender::setParameters: ${e.message}';
     }


### PR DESCRIPTION
Web implementation of `RTCPeerConnection .removeTrack` and `RTCRtpSender.setParameters` raises following exception. 

> Expected a value of type 'FutureOr<bool>', but got one of type 'Null' 

Actually, at the javascript implementation, type of the return value of these two functions is `void`, but implementation of `RTCPeerConnection .removeTrack` and `RTCRtpSender.setParameters` are assuming that the return type is `bool`.

To prevent this exception, I changed these two functions to ignore the return value came from javascript version of the function and just return a `true`. 