### PR TITLE
[web] Switch transferFromImageBitmap to be invoked using js.callMethod

### DIFF
--- a/lib/src/web/media_stream_track_impl.dart
+++ b/lib/src/web/media_stream_track_impl.dart
@@ -67,7 +67,7 @@ class MediaStreamTrackWeb extends MediaStreamTrack {
     canvas.height = bitmap.height;
     final renderer =
         canvas.getContext('bitmaprenderer') as html.ImageBitmapRenderingContext;
-    renderer.transferFromImageBitmap(bitmap);
+    js.callMethod(renderer, 'transferFromImageBitmap', [bitmap]);
     final blod = await canvas.toBlob();
     var array =
         await js.promiseToFuture(js.callMethod(blod, 'arrayBuffer', []));


### PR DESCRIPTION
The current implementation of captureFrame works in debug mode but fails in
profile and release mode with `TypeError: ... is not a function`. This commit
uses js.callMethod to invoke the method instead of using the native api, which
seems to resolve this issue.

Fixes #621