### PR TITLE
web: avoid removing all audio elements when stopping a single video renderer

### DIFF
--- a/lib/src/web/rtc_video_renderer_impl.dart
+++ b/lib/src/web/rtc_video_renderer_impl.dart
@@ -35,6 +35,8 @@ const String _kDefaultErrorMessage =
 class RTCVideoRendererWeb extends VideoRenderer {
   RTCVideoRendererWeb() : _textureId = _textureCounter++;
 
+  static const _elementIdForAudioManager = 'html_webrtc_audio_manager_list';
+
   html.AudioElement? _audioElement;
 
   static int _textureCounter = 1;
@@ -76,8 +78,11 @@ class RTCVideoRendererWeb extends VideoRenderer {
   @override
   bool get renderVideo => _srcObject != null;
 
+  String get _elementIdForAudio => 'audio_RTCVideoRenderer-$textureId';
+  String get _elementIdForVideo => 'video_RTCVideoRenderer-$textureId';
+
   void _updateAllValues() {
-    var element = findHtmlView();
+    final element = findHtmlView();
     value = value.copyWith(
       rotation: 0,
       width: element?.videoWidth.toDouble() ?? 0.0,
@@ -103,13 +108,13 @@ class RTCVideoRendererWeb extends VideoRenderer {
     if (null != _srcObject) {
       if (stream.getVideoTracks().isNotEmpty) {
         _videoStream = html.MediaStream();
-        for (var track in _srcObject!.jsStream.getVideoTracks()) {
+        for (final track in _srcObject!.jsStream.getVideoTracks()) {
           _videoStream!.addTrack(track);
         }
       }
       if (stream.getAudioTracks().isNotEmpty) {
         _audioStream = html.MediaStream();
-        for (var track in _srcObject!.jsStream.getAudioTracks()) {
+        for (final track in _srcObject!.jsStream.getAudioTracks()) {
           _audioStream!.addTrack(track);
         }
       }
@@ -121,10 +126,10 @@ class RTCVideoRendererWeb extends VideoRenderer {
     if (null != _audioStream) {
       if (null == _audioElement) {
         _audioElement = html.AudioElement()
-          ..id = 'audio_RTCVideoRenderer-$textureId'
+          ..id = _elementIdForAudio
           ..muted = stream.ownerTag == 'local'
           ..autoplay = true;
-        getAudioManageDiv().append(_audioElement!);
+        _ensureAudioManagerDiv().append(_audioElement!);
       }
       _audioElement?.srcObject = _audioStream;
     }
@@ -134,29 +139,26 @@ class RTCVideoRendererWeb extends VideoRenderer {
     value = value.copyWith(renderVideo: renderVideo);
   }
 
-  html.DivElement getAudioManageDiv() {
-    var div = html.document.getElementById('html_webrtc_audio_manage_list');
-    if (null != div) {
-      return div as html.DivElement;
-    }
-    div = html.DivElement();
-    div.id = 'html_webrtc_audio_manage_list';
-    div.style.display = 'none';
-    html.document.body!.append(div);
+  html.DivElement _ensureAudioManagerDiv() {
+    var div = html.document.getElementById(_elementIdForAudioManager);
+    if (null != div) return div as html.DivElement;
+
+    div = html.DivElement()
+      ..id = _elementIdForAudioManager
+      ..style.display = 'none';
+    html.document.body?.append(div);
     return div as html.DivElement;
   }
 
   html.VideoElement? findHtmlView() {
-    var video =
-        html.document.getElementById('video_RTCVideoRenderer-$textureId');
-    if (null != video) {
-      return video as html.VideoElement;
-    }
+    final video = html.document.getElementById(_elementIdForVideo);
+    if (null != video) return video as html.VideoElement;
+
     final fltPv = html.document.getElementsByTagName('flt-platform-view');
     if (fltPv.isEmpty) return null;
-    var child = (fltPv.first as html.Element).shadowRoot!.childNodes;
-    for (var item in child) {
-      if ((item as html.Element).id == 'video_RTCVideoRenderer-$textureId') {
+    final child = (fltPv.first as html.Element).shadowRoot!.childNodes;
+    for (final item in child) {
+      if ((item as html.Element).id == _elementIdForVideo) {
         return item as html.VideoElement;
       }
     }
@@ -168,17 +170,19 @@ class RTCVideoRendererWeb extends VideoRenderer {
     await _srcObject?.dispose();
     _srcObject = null;
     _subscriptions.forEach((s) => s.cancel());
-    var element = findHtmlView();
+    final element = findHtmlView();
     element?.removeAttribute('src');
     element?.load();
-    getAudioManageDiv().remove();
+    _audioElement?.remove();
+    final audioManager = html.document.getElementById(_elementIdForAudioManager) as html.DivElement?;
+    if (audioManager != null && !audioManager.hasChildNodes()) audioManager.remove();
     return super.dispose();
   }
 
   @override
   Future<bool> audioOutput(String deviceId) async {
     try {
-      var element = findHtmlView();
+      final element = findHtmlView();
       if (null != element && jsutil.hasProperty(element, 'setSinkId')) {
         await jsutil.promiseToFuture<void>(
             jsutil.callMethod(element, 'setSinkId', [deviceId]));
@@ -193,13 +197,12 @@ class RTCVideoRendererWeb extends VideoRenderer {
 
   @override
   Future<void> initialize() async {
-    var id = 'RTCVideoRenderer-$textureId';
     // // ignore: undefined_prefixed_name
-    ui.platformViewRegistry.registerViewFactory(id, (int viewId) {
+    ui.platformViewRegistry.registerViewFactory('RTCVideoRenderer-$textureId', (int viewId) {
       _subscriptions.forEach((s) => s.cancel());
       _subscriptions.clear();
 
-      var element = html.VideoElement()
+      final element = html.VideoElement()
         ..autoplay = true
         ..muted = true
         ..controls = false
@@ -208,7 +211,7 @@ class RTCVideoRendererWeb extends VideoRenderer {
         ..style.width = '100%'
         ..style.height = '100%'
         ..srcObject = _videoStream
-        ..id = 'video_$id'
+        ..id = _elementIdForVideo
         ..setAttribute('playsinline', 'true');
 
       _subscriptions.add(
@@ -232,7 +235,7 @@ class RTCVideoRendererWeb extends VideoRenderer {
           // The Event itself (_) doesn't contain info about the actual error.
           // We need to look at the HTMLMediaElement.error.
           // See: https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/error
-          var error = element.error;
+          final error = element.error;
           print('RTCVideoRenderer: videoElement.onError, ${error.toString()}');
           throw PlatformException(
             code: _kErrorValueToErrorName[error!.code]!,

--- a/lib/src/web/rtc_video_renderer_impl.dart
+++ b/lib/src/web/rtc_video_renderer_impl.dart
@@ -57,8 +57,11 @@ class RTCVideoRendererWeb extends VideoRenderer {
 
   bool _muted = false;
 
-  set objectFit(String fit) =>
-      findHtmlView()?.style.objectFit = _objectFit = fit;
+  set objectFit(String fit) {
+    if (_objectFit == fit) return;
+    _objectFit = fit;
+    findHtmlView()?.style.objectFit = fit;
+  }
 
   @override
   int get videoWidth => value.width.toInt();


### PR DESCRIPTION
When a single video renderer is removed, it removes the entire audio manager div, causing all audio tracks to stop playback.