### PR TITLE
Web related fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 *.iml
 .idea
 .DS_Store
-.vscode/.DS_Store
 example/pubspec.lock
 pubspec.lock
 example/ios/Podfile.lock
@@ -17,8 +16,6 @@ example/ios/Runner/GeneratedPluginRegistrant.m
 example/ios/Runner/GeneratedPluginRegistrant.h
 example/ios/Flutter/Generated.xcconfig
 example/ios/Flutter/flutter_export_environment.sh
-.vscode/launch.json
-example/.vscode/launch.json
 
 # Miscellaneous
 *.class
@@ -51,3 +48,6 @@ example/.vscode/launch.json
 
 android/.classpath
 android/.settings/org.eclipse.buildship.core.prefs
+
+# VSCode
+.vscode/

--- a/lib/src/interface/media_stream_track.dart
+++ b/lib/src/interface/media_stream_track.dart
@@ -72,6 +72,11 @@ abstract class MediaStreamTrack {
 
   Future<void> stop();
 
+  //
+  // https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack/getSettings
+  //
+  Map<String, dynamic> getSettings() => throw UnimplementedError();
+
   /// Throws error if switching camera failed
   @Deprecated('use Helper.switchCamera() instead')
   Future<bool> switchCamera() {

--- a/lib/src/web/media_stream_track_impl.dart
+++ b/lib/src/web/media_stream_track_impl.dart
@@ -59,6 +59,11 @@ class MediaStreamTrackWeb extends MediaStreamTrack {
   // }
 
   @override
+  Map<String, dynamic> getSettings() {
+    return jsTrack.getSettings() as Map<String, dynamic>;
+  }
+
+  @override
   Future<ByteBuffer> captureFrame() async {
     final imageCapture = html.ImageCapture(jsTrack);
     final bitmap = await imageCapture.grabFrame();

--- a/lib/src/web/rtc_peerconnection_impl.dart
+++ b/lib/src/web/rtc_peerconnection_impl.dart
@@ -369,18 +369,31 @@ class RTCPeerConnectionWeb extends RTCPeerConnection {
   }
 
   //'audio|video', { 'direction': 'recvonly|sendonly|sendrecv' }
+  //
+  // https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/addTransceiver
+  //
   @override
-  Future<RTCRtpTransceiver> addTransceiver(
-      {MediaStreamTrack? track,
-      RTCRtpMediaType? kind,
-      RTCRtpTransceiverInit? init}) async {
-    var kindLabel = kind != null ? typeRTCRtpMediaTypetoString[kind] : null;
-    var kindOrTrack = kindLabel ?? (track as MediaStreamTrackWeb).jsTrack;
-    final jsOptions = jsutil
-        .jsify(init != null ? RTCRtpTransceiverInitWeb.initToMap(init) : {});
-    var transceiver =
-        jsutil.callMethod(_jsPc, 'addTransceiver', [kindOrTrack, jsOptions]);
-    return RTCRtpTransceiverWeb.fromJsObject(transceiver,
-        peerConnectionId: _peerConnectionId);
+  Future<RTCRtpTransceiver> addTransceiver({
+    MediaStreamTrack? track,
+    RTCRtpMediaType? kind,
+    RTCRtpTransceiverInit? init,
+  }) async {
+    final jsTrack = track is MediaStreamTrackWeb ? track.jsTrack : null;
+    final kindString = kind != null ? typeRTCRtpMediaTypetoString[kind] : null;
+    final trackOrKind = jsTrack ?? kindString;
+    final jsOptions = jsutil.jsify(
+      init is RTCRtpTransceiverInitWeb ? init.toJSMap() : {},
+    );
+
+    final transceiver = jsutil.callMethod(
+      _jsPc,
+      'addTransceiver',
+      [trackOrKind, jsOptions],
+    );
+
+    return RTCRtpTransceiverWeb.fromJsObject(
+      transceiver,
+      peerConnectionId: _peerConnectionId,
+    );
   }
 }

--- a/lib/src/web/rtc_rtp_transceiver_impl.dart
+++ b/lib/src/web/rtc_rtp_transceiver_impl.dart
@@ -39,26 +39,21 @@ class RTCRtpTransceiverInitWeb extends RTCRtpTransceiverInit {
         listToRtpEncodings(map['sendEncodings']));
   }
 
-  Map<String, dynamic> toMap() {
-    return {
-      'direction': typeRtpTransceiverDirectionToString[direction],
-      if (streams != null) 'streamIds': streams!.map((e) => e.id).toList(),
-      if (sendEncodings != null)
-        'sendEncodings': sendEncodings!.map((e) => e.toMap()).toList(),
-    };
-  }
+  Map<String, dynamic> toMap() => {
+        'direction': typeRtpTransceiverDirectionToString[direction],
+        if (streams != null) 'streamIds': streams!.map((e) => e.id).toList(),
+        if (sendEncodings != null)
+          'sendEncodings': sendEncodings!.map((e) => e.toMap()).toList(),
+      };
 
-  static Map<String, dynamic> initToMap(RTCRtpTransceiverInit init) {
-    return {
-      'direction': typeRtpTransceiverDirectionToString[init.direction],
-      'streams': init.streams != null
-          ? init.streams!.map((e) => (e as MediaStreamWeb).jsStream).toList()
-          : [],
-      'sendEncodings': init.sendEncodings != null
-          ? init.sendEncodings!.map((e) => e.toMap()).toList()
-          : [],
-    };
-  }
+  Map<String, dynamic> toJSMap() => {
+        'direction': typeRtpTransceiverDirectionToString[direction],
+        if (streams != null)
+          'streams':
+              streams!.map((e) => (e as MediaStreamWeb).jsStream).toList(),
+        if (sendEncodings != null)
+          'sendEncodings': sendEncodings!.map((e) => e.toMap()).toList(),
+      };
 }
 
 class RTCRtpTransceiverWeb extends RTCRtpTransceiver {


### PR DESCRIPTION
- Added `MediaStreamTrack.getSettings` for Web
- `RTCPeerConnection.addTransceiver` for Web uses `track` instead of `kind` when both are specified.