### PR TITLE
Switch to custom WebRTC build for iOS

### DIFF
--- a/common/darwin/Classes/FlutterWebRTCPlugin.m
+++ b/common/darwin/Classes/FlutterWebRTCPlugin.m
@@ -64,9 +64,12 @@
     //RTCSetMinDebugLogLevel(RTCLoggingSeverityVerbose);
     RTCDefaultVideoDecoderFactory *decoderFactory = [[RTCDefaultVideoDecoderFactory alloc] init];
     RTCDefaultVideoEncoderFactory *encoderFactory = [[RTCDefaultVideoEncoderFactory alloc] init];
-    
+
+    RTCVideoEncoderFactorySimulcast *simulcastFactory = [[RTCVideoEncoderFactorySimulcast alloc]  initWithPrimary:encoderFactory
+                                                                                                         fallback:encoderFactory];
+
     _peerConnectionFactory = [[RTCPeerConnectionFactory alloc]
-                              initWithEncoderFactory:encoderFactory
+                              initWithEncoderFactory:simulcastFactory
                               decoderFactory:decoderFactory];
     
     

--- a/ios/flutter_webrtc.podspec
+++ b/ios/flutter_webrtc.podspec
@@ -16,7 +16,7 @@ A new flutter plugin project.
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
   s.dependency 'Libyuv', '1703'
-  s.dependency 'GoogleWebRTC', '1.1.31999'
+  s.dependency 'WebRTC-SDK', '92.4515.02.exp'
   s.ios.deployment_target = '10.0'
   s.static_framework = true
 end

--- a/ios/flutter_webrtc.podspec
+++ b/ios/flutter_webrtc.podspec
@@ -16,7 +16,7 @@ A new flutter plugin project.
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
   s.dependency 'Libyuv', '1703'
-  s.dependency 'unx_webrtc', '2021092000'
+  s.dependency 'WebRTC-SDK', '92.4515.04'
   s.ios.deployment_target = '10.0'
   s.static_framework = true
 end

--- a/ios/flutter_webrtc.podspec
+++ b/ios/flutter_webrtc.podspec
@@ -16,7 +16,7 @@ A new flutter plugin project.
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
   s.dependency 'Libyuv', '1703'
-  s.dependency 'WebRTC-SDK', '92.4515.02.exp'
+  s.dependency 'unx_webrtc', '2021092000'
   s.ios.deployment_target = '10.0'
   s.static_framework = true
 end


### PR DESCRIPTION
**After we confirm** custom build is stable we should switch to it.

### Q. Should we default to `RTCVideoEncoderFactorySimulcast` ?
I'm not sure if there are any side-effects using `RTCVideoEncoderFactorySimulcast` for non-simulcast mode.
