### PR TITLE
Enable audio capture when acquiring track

### DIFF
--- a/common/darwin/Classes/FlutterWebRTCPlugin.m
+++ b/common/darwin/Classes/FlutterWebRTCPlugin.m
@@ -659,10 +659,6 @@
             return;
         }
 
-        if ([track.kind isEqualToString:@"audio"]) {
-            [AudioUtils ensureAudioSessionWithRecording:YES];
-        }
-
         result([self rtpSenderToMap:sender]);
     } else if ([@"removeTrack" isEqualToString:call.method]){
         NSDictionary* argsMap = call.arguments;
@@ -732,10 +728,6 @@
             message:[NSString stringWithFormat:@"Error: can't addTransceiver!"]
             details:nil]);
             return;
-        }
-
-        if (hasAudio) {
-            [AudioUtils ensureAudioSessionWithRecording:YES];
         }
 
         result([self transceiverToMap:transceiver]);


### PR DESCRIPTION
Fixing issues observed with original PR #705. This allows us to enable mic permissions much earlier on, regardless of how the user publishes the track.