### PR TITLE
[Windows]为兼容目前的Flutter 的onRemoveTrack处理方式,添加必要参数

### DIFF
--- a/common/cpp/src/flutter_peerconnection.cc
+++ b/common/cpp/src/flutter_peerconnection.cc
@@ -1058,11 +1058,13 @@ void FlutterPeerConnectionObserver::OnTrack(
 
 void FlutterPeerConnectionObserver::OnRemoveTrack(
     scoped_refptr<RTCRtpReceiver> receiver) {
+    auto track = receiver->track();
   if (event_sink_ != nullptr) {
     EncodableMap params;
     params[EncodableValue("event")] = "onRemoveTrack";
+    params[EncodableValue("trackId")] = EncodableValue(track->id().std_string());
+    params[EncodableValue("track")] = EncodableValue(mediaTrackToMap(track));
     params[EncodableValue("receiver")] = EncodableValue(rtpReceiverToMap(receiver));
-
     event_sink_->Success(EncodableValue(params));
   }
 }


### PR DESCRIPTION
Windows 中的 onRemoveTrack 缺少参数。