### PR TITLE
Properly start foreground service in example

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -32,7 +32,8 @@ Future<bool> startForegroundService() async {
         name: 'background_icon',
         defType: 'drawable'), // Default is ic_launcher from folder mipmap
   );
-  return FlutterBackground.initialize(androidConfig: androidConfig);
+  await FlutterBackground.initialize(androidConfig: androidConfig);
+  return FlutterBackground.enableBackgroundExecution();
 }
 
 class MyApp extends StatefulWidget {


### PR DESCRIPTION
Example app currently only initializes FlutterBackground, and doesn't actually start it.