### PR TITLE
New video constraints syntax

### DIFF
--- a/android/src/main/java/com/cloudwebrtc/webrtc/GetUserMediaImpl.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/GetUserMediaImpl.java
@@ -428,16 +428,6 @@ class GetUserMediaImpl {
 
     void getDisplayMedia(
             final ConstraintsMap constraints, final Result result, final MediaStream mediaStream) {
-        ConstraintsMap videoConstraintsMap = null;
-        ConstraintsMap videoConstraintsMandatory = null;
-
-        if (constraints.getType("video") == ObjectType.Map) {
-            videoConstraintsMap = constraints.getMap("video");
-            if (videoConstraintsMap.hasKey("mandatory")
-                    && videoConstraintsMap.getType("mandatory") == ObjectType.Map) {
-                videoConstraintsMandatory = videoConstraintsMap.getMap("mandatory");
-            }
-        }
 
         screenRequestPremissions(
                 new ResultReceiver(new Handler(Looper.getMainLooper())) {

--- a/android/src/main/java/com/cloudwebrtc/webrtc/GetUserMediaImpl.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/GetUserMediaImpl.java
@@ -88,7 +88,7 @@ class GetUserMediaImpl {
     private static final String PERMISSION_AUDIO = Manifest.permission.RECORD_AUDIO;
     private static final String PERMISSION_VIDEO = Manifest.permission.CAMERA;
     private static final String PERMISSION_SCREEN = "android.permission.MediaProjection";
-    private static int CAPTURE_PERMISSION_REQUEST_CODE = 1;
+    private static final int CAPTURE_PERMISSION_REQUEST_CODE = 1;
     private static final String GRANT_RESULTS = "GRANT_RESULT";
     private static final String PERMISSIONS = "PERMISSION";
     private static final String PROJECTION_DATA = "PROJECTION_DATA";
@@ -103,8 +103,6 @@ class GetUserMediaImpl {
     private final Context applicationContext;
 
     static final int minAPILevel = Build.VERSION_CODES.LOLLIPOP;
-    private MediaProjectionManager mProjectionManager = null;
-    private static MediaProjection sMediaProjection = null;
 
     final AudioSamplesInterceptor inputSamplesInterceptor = new AudioSamplesInterceptor();
     private OutputAudioSamplesInterceptor outputSamplesInterceptor = null;
@@ -357,17 +355,6 @@ class GetUserMediaImpl {
         //   should change `parseConstraints()` according
         //   see: https://www.w3.org/TR/mediacapture-streams/#idl-def-MediaTrackConstraints
 
-        ConstraintsMap videoConstraintsMap = null;
-        ConstraintsMap videoConstraintsMandatory = null;
-
-        if (constraints.getType("video") == ObjectType.Map) {
-            videoConstraintsMap = constraints.getMap("video");
-            if (videoConstraintsMap.hasKey("mandatory")
-                    && videoConstraintsMap.getType("mandatory") == ObjectType.Map) {
-                videoConstraintsMandatory = videoConstraintsMap.getMap("mandatory");
-            }
-        }
-
         final ArrayList<String> requestPermissions = new ArrayList<>();
 
         if (constraints.hasKey("audio")) {
@@ -451,8 +438,6 @@ class GetUserMediaImpl {
                 videoConstraintsMandatory = videoConstraintsMap.getMap("mandatory");
             }
         }
-
-        final ConstraintsMap videoConstraintsMandatory2 = videoConstraintsMandatory;
 
         screenRequestPremissions(
                 new ResultReceiver(new Handler(Looper.getMainLooper())) {

--- a/android/src/main/java/com/cloudwebrtc/webrtc/utils/ConstraintsMap.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/utils/ConstraintsMap.java
@@ -128,4 +128,11 @@ public class ConstraintsMap {
     public ArrayList<Object> getListArray(String name){
         return (ArrayList<Object>) mMap.get(name);
     }
+
+    @Override
+    public String toString() {
+        return "ConstraintsMap{" +
+                "mMap=" + mMap +
+                '}';
+    }
 }

--- a/android/src/main/java/com/cloudwebrtc/webrtc/utils/MediaConstraintsUtils.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/utils/MediaConstraintsUtils.java
@@ -24,6 +24,11 @@ public class MediaConstraintsUtils {
   public static MediaConstraints parseMediaConstraints(ConstraintsMap constraints) {
     MediaConstraints mediaConstraints = new MediaConstraints();
 
+    // TODO: change getUserMedia constraints format to support new syntax
+    //   constraint format seems changed, and there is no mandatory any more.
+    //   and has a new syntax/attrs to specify resolution
+    //   should change `parseConstraints()` according
+    //   see: https://www.w3.org/TR/mediacapture-streams/#idl-def-MediaTrackConstraints
     if (constraints.hasKey("mandatory")
         && constraints.getType("mandatory") == ObjectType.Map) {
       parseConstraints(constraints.getMap("mandatory"),

--- a/common/darwin/Classes/FlutterRTCMediaStream.m
+++ b/common/darwin/Classes/FlutterRTCMediaStream.m
@@ -195,6 +195,34 @@ typedef void (^NavigatorUserMediaSuccessCallback)(RTCMediaStream *mediaStream);
     successCallback(mediaStream);
 }
 
+- (int)getConstrainInt:(NSDictionary *)constraints
+                forKey:(NSString *)key {
+    
+    if (![constraints isKindOfClass:[NSDictionary class]]) {
+        return 0;
+    }
+
+    id constraint = constraints[key];
+    if ([constraint isKindOfClass:[NSNumber class]]) {
+        return [constraint intValue];
+    } else if ([constraint isKindOfClass:[NSString class]]) {
+        int possibleValue = [constraint intValue];
+        if (possibleValue != 0) {
+            return possibleValue;
+        }
+    } else if ([constraint isKindOfClass:[NSDictionary class]]) {
+        id idealConstraint = constraint[@"ideal"];
+        if([idealConstraint isKindOfClass: [NSString class]]) {
+            int possibleValue = [idealConstraint intValue];
+            if(possibleValue != 0){
+                return possibleValue;
+            }
+        }
+    }
+    
+    return 0;
+}
+
 /**
  * Initializes a new {@link RTCVideoTrack} which satisfies specific constraints,
  * adds it to a specific {@link RTCMediaStream}, and reports success to a
@@ -299,6 +327,21 @@ typedef void (^NavigatorUserMediaSuccessCallback)(RTCMediaStream *mediaStream);
                 self._targetFps = possibleFps;
             }
         }
+    }
+
+    int possibleWidth = [self getConstrainInt:videoConstraints forKey:@"width"];
+    if(possibleWidth != 0){
+        self._targetWidth = possibleWidth;
+    }
+    
+    int possibleHeight = [self getConstrainInt:videoConstraints forKey:@"height"];
+    if(possibleHeight != 0){
+        self._targetHeight = possibleHeight;
+    }
+    
+    int possibleFps = [self getConstrainInt:videoConstraints forKey:@"frameRate"];
+    if(possibleFps != 0){
+        self._targetFps = possibleFps;
     }
 
     if (videoDevice) {


### PR DESCRIPTION
Updating getUserMedia to use latest video constraint syntax (https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints).

Current getUserMedia constraints have been deprecated for years (and documentation is very sparse), so we should start looking to support the latest syntax.