### PR TITLE
[windows] Fix mute

### DIFF
--- a/common/cpp/src/flutter_media_stream.cc
+++ b/common/cpp/src/flutter_media_stream.cc
@@ -342,5 +342,7 @@ void FlutterMediaStream::MediaStreamTrackSwitchCamera(
 
 void FlutterMediaStream::MediaStreamTrackDispose(
     const std::string& track_id,
-    std::unique_ptr<MethodResult<EncodableValue>> result) {}
+    std::unique_ptr<MethodResult<EncodableValue>> result) {
+    result->Success();
+}
 }  // namespace flutter_webrtc_plugin


### PR DESCRIPTION
There was no response to trackDispose method call.
That causes failure in client code and therefore not working mute.