### PR TITLE
Fix issue with getting remote track

### DIFF
--- a/common/cpp/include/flutter_peerconnection.h
+++ b/common/cpp/include/flutter_peerconnection.h
@@ -33,6 +33,8 @@ class FlutterPeerConnectionObserver : public RTCPeerConnectionObserver {
 
   scoped_refptr<RTCMediaStream> MediaStreamForId(const std::string& id);
 
+  scoped_refptr<RTCMediaTrack> MediaTrackForId(const std::string& id);
+
   void RemoveStreamForId(const std::string& id);
 
  private:

--- a/common/cpp/src/flutter_peerconnection.cc
+++ b/common/cpp/src/flutter_peerconnection.cc
@@ -1145,6 +1145,26 @@ scoped_refptr<RTCMediaStream> FlutterPeerConnectionObserver::MediaStreamForId(
   return nullptr;
 }
 
+scoped_refptr<RTCMediaTrack> FlutterPeerConnectionObserver::MediaTrackForId(const std::string& id) {
+    for (auto it = remote_streams_.begin(); it != remote_streams_.end(); it++)
+    {
+        auto remoteStream = (*it).second;
+        auto audio_tracks = remoteStream->audio_tracks();
+        for (auto track : audio_tracks.std_vector()) {
+            if (track->id().std_string() == id) {
+                return track;
+            }
+        }
+        auto video_tracks = remoteStream->video_tracks();
+        for (auto track : video_tracks.std_vector()) {
+            if (track->id().std_string() == id) {
+                return track;
+            }
+        }
+    }
+    return nullptr;
+}
+
 void FlutterPeerConnectionObserver::RemoveStreamForId(const std::string& id) {
   auto it = remote_streams_.find(id);
   if (it != remote_streams_.end())

--- a/common/cpp/src/flutter_webrtc_base.cc
+++ b/common/cpp/src/flutter_webrtc_base.cc
@@ -42,6 +42,12 @@ RTCMediaTrack* FlutterWebRTCBase ::MediaTrackForId(const std::string& id) {
   if (it != local_tracks_.end())
     return (*it).second.get();
 
+  for (auto kv : peerconnection_observers_) {
+      auto pco = kv.second.get();
+      auto track = pco->MediaTrackForId(id);
+      if (track != nullptr) return track;
+  }
+
   return nullptr;
 }
 

--- a/lib/src/web/rtc_video_renderer_impl.dart
+++ b/lib/src/web/rtc_video_renderer_impl.dart
@@ -3,11 +3,10 @@ import 'dart:html' as html;
 import 'dart:js_util' as jsutil;
 import 'dart:ui' as ui;
 
-import 'package:flutter/foundation.dart';
-import 'package:flutter/services.dart';
-
 import 'package:dart_webrtc/dart_webrtc.dart';
 import 'package:dart_webrtc/src/media_stream_impl.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 import 'package:webrtc_interface/webrtc_interface.dart';
 
 // An error code value to error name Map.

--- a/lib/src/web/rtc_video_view_impl.dart
+++ b/lib/src/web/rtc_video_view_impl.dart
@@ -1,9 +1,8 @@
 import 'dart:async';
 import 'dart:math';
 
-import 'package:flutter/material.dart';
-
 import 'package:dart_webrtc/dart_webrtc.dart';
+import 'package:flutter/material.dart';
 import 'package:webrtc_interface/webrtc_interface.dart';
 
 import 'rtc_video_renderer_impl.dart';


### PR DESCRIPTION
In FlutterWebRTCBase::MediaTrackForId only local tracks were looked in.
Added also looking in remote tracks.

The problem was visible as described. When joining a session and trying to enable a track inside flutter_webrtc there is a call
`RTCMediaTrack* track = MediaTrackForId(track_id);`

That returned `nullptr` and exception was thrown:
`result->Error("mediaStreamTrackSetEnableFailed", "mediaStreamTrackSetEnable() track is null");`