### PR TITLE
Better handling of `rid` in `sender.parameters.encodings`

### DIFF
--- a/android/src/main/java/com/cloudwebrtc/webrtc/PeerConnectionObserver.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/PeerConnectionObserver.java
@@ -763,6 +763,9 @@ class PeerConnectionObserver implements PeerConnection.Observer, EventChannel.St
       for(RtpParameters.Encoding encoding : rtpParameters.encodings){
           ConstraintsMap map = new ConstraintsMap();
           map.putBoolean("active",encoding.active);
+          if (encoding.rid != null) {
+              map.putString("rid", encoding.rid);
+          }
           if (encoding.maxBitrateBps != null) {
               map.putInt("maxBitrate", encoding.maxBitrateBps);
           }

--- a/android/src/main/java/com/cloudwebrtc/webrtc/PeerConnectionObserver.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/PeerConnectionObserver.java
@@ -711,34 +711,52 @@ class PeerConnectionObserver implements PeerConnection.Observer, EventChannel.St
       return  init;
   }
 
-  private RtpParameters updateRtpParameters(Map<String, Object> newParameters, RtpParameters parameters){
-    List<Map<String, Object>> encodings = (List<Map<String, Object>>) newParameters.get("encodings");
-    final Iterator encodingsIterator = encodings.iterator();
-    final Iterator nativeEncodingsIterator = parameters.encodings.iterator();
-    while(encodingsIterator.hasNext() && nativeEncodingsIterator.hasNext()){
-      final RtpParameters.Encoding nativeEncoding = (RtpParameters.Encoding) nativeEncodingsIterator.next();
-      final Map<String, Object> encoding = (Map<String, Object>) encodingsIterator.next();
-      if(encoding.containsKey("active")){
-        nativeEncoding.active =  (Boolean) encoding.get("active");
-      }
-      if (encoding.containsKey("maxBitrate")) {
-        nativeEncoding.maxBitrateBps = (Integer) encoding.get("maxBitrate");
-      }
-      if (encoding.containsKey("minBitrate")) {
-        nativeEncoding.minBitrateBps = (Integer) encoding.get("minBitrate");
-      }
-      if (encoding.containsKey("maxFramerate")) {
-        nativeEncoding.maxFramerate = (Integer) encoding.get("maxFramerate");
-      }
-      if (encoding.containsKey("numTemporalLayers")) {
-        nativeEncoding.numTemporalLayers = (Integer) encoding.get("numTemporalLayers");
-      }
-      if (encoding.containsKey("scaleResolutionDownBy") ) {
-        nativeEncoding.scaleResolutionDownBy = (Double) encoding.get("scaleResolutionDownBy");
-      }
+private RtpParameters updateRtpParameters(RtpParameters parameters, Map<String, Object> newParameters) {
+    // new
+    final List<Map<String, Object>> encodings = (List<Map<String, Object>>)newParameters.get("encodings");
+    // current
+    final List<RtpParameters.Encoding> nativeEncodings = parameters.encodings;
+
+    for (Map<String, Object> encoding: encodings) {
+        RtpParameters.Encoding currentParams = null;
+        String rid = (String)encoding.get("rid");
+
+        // find by rid
+        if (rid != null) {
+            for (RtpParameters.Encoding x : nativeEncodings) {
+                if (rid.equals(x.rid)) {
+                    currentParams = x;
+                    break;
+                }
+            }
+        }
+
+        // fall back to index
+        if (currentParams == null) {
+            int idx = encodings.indexOf(encoding);
+            if (idx < nativeEncodings.size()) {
+                currentParams = nativeEncodings.get(idx);
+            }
+        }
+
+        if (currentParams != null) {
+          Boolean active = (Boolean)encoding.get("active");
+          if (active != null) currentParams.active = active;
+          Integer maxBitrate = (Integer)encoding.get("maxBitrate");
+          if (maxBitrate != null) currentParams.maxBitrateBps = maxBitrate;
+          Integer minBitrate = (Integer)encoding.get("minBitrate");
+          if (minBitrate != null) currentParams.minBitrateBps = minBitrate;
+          Integer maxFramerate = (Integer)encoding.get("maxFramerate");
+          if (maxFramerate != null) currentParams.maxFramerate = maxFramerate; 
+          Integer numTemporalLayers = (Integer)encoding.get("numTemporalLayers");
+          if (numTemporalLayers != null) currentParams.numTemporalLayers = numTemporalLayers;
+          Double scaleResolutionDownBy = (Double)encoding.get("scaleResolutionDownBy");
+          if (scaleResolutionDownBy != null) currentParams.scaleResolutionDownBy = scaleResolutionDownBy;  
+        }
     }
+
     return parameters;
-  }
+}
 
   private Map<String, Object> rtpParametersToMap(RtpParameters rtpParameters){
       ConstraintsMap info = new ConstraintsMap();
@@ -1004,7 +1022,7 @@ class PeerConnectionObserver implements PeerConnection.Observer, EventChannel.St
             resultError("rtpSenderSetParameters", "sender is null", result);
             return;
         }
-        final RtpParameters updatedParameters = updateRtpParameters(parameters, sender.getParameters());
+        final RtpParameters updatedParameters = updateRtpParameters(sender.getParameters(), parameters);
         final Boolean success = sender.setParameters(updatedParameters);
         ConstraintsMap params = new ConstraintsMap();
         params.putBoolean("result", success);

--- a/common/darwin/Classes/FlutterWebRTCPlugin.m
+++ b/common/darwin/Classes/FlutterWebRTCPlugin.m
@@ -1351,6 +1351,7 @@
     NSMutableArray *encodings = [NSMutableArray array];
     for (RTCRtpEncodingParameters* encoding in parameters.encodings) {
         [encodings addObject:@{
+            @"rid": encoding.rid,
             @"active": @(encoding.isActive),
             @"minBitrate": encoding.minBitrateBps? encoding.minBitrateBps : [NSNumber numberWithInt:0],
             @"maxBitrate": encoding.maxBitrateBps? encoding.maxBitrateBps : [NSNumber numberWithInt:0],

--- a/common/darwin/Classes/FlutterWebRTCPlugin.m
+++ b/common/darwin/Classes/FlutterWebRTCPlugin.m
@@ -1350,16 +1350,17 @@
 
     NSMutableArray *encodings = [NSMutableArray array];
     for (RTCRtpEncodingParameters* encoding in parameters.encodings) {
-        NSMutableDictionary *obj = [@{
-            @"active": @(encoding.isActive),
-            @"minBitrate": encoding.minBitrateBps? encoding.minBitrateBps : [NSNumber numberWithInt:0],
-            @"maxBitrate": encoding.maxBitrateBps? encoding.maxBitrateBps : [NSNumber numberWithInt:0],
-            @"maxFramerate": encoding.maxFramerate? encoding.maxFramerate : @(30),
-            @"numTemporalLayers": encoding.numTemporalLayers? encoding.numTemporalLayers : @(1),
-            @"scaleResolutionDownBy": encoding.scaleResolutionDownBy? @(encoding.scaleResolutionDownBy.doubleValue) : [NSNumber numberWithDouble:1.0],
-            @"ssrc": encoding.ssrc ? encoding.ssrc : [NSNumber numberWithLong:0]
-        } mutableCopy];
-        if ([encoding.rid length] != 0) [obj setObject:encoding.rid forKey:@"rid"];
+        // non-nil values
+        NSMutableDictionary *obj = [@{@"active": @(encoding.isActive)} mutableCopy];
+        // optional values
+        if (encoding.rid != nil) [obj setObject:encoding.rid forKey:@"rid"];
+        if (encoding.minBitrateBps != nil) [obj setObject:encoding.minBitrateBps forKey:@"minBitrate"];
+        if (encoding.maxBitrateBps != nil) [obj setObject:encoding.maxBitrateBps forKey:@"maxBitrate"];
+        if (encoding.maxFramerate != nil) [obj setObject:encoding.maxFramerate forKey:@"maxFramerate"];
+        if (encoding.numTemporalLayers != nil) [obj setObject:encoding.numTemporalLayers forKey:@"numTemporalLayers"];
+        if (encoding.scaleResolutionDownBy != nil) [obj setObject:encoding.scaleResolutionDownBy forKey:@"scaleResolutionDownBy"];
+        if (encoding.ssrc != nil) [obj setObject:encoding.ssrc forKey:@"ssrc"];
+
         [encodings addObject:obj];
     }
 

--- a/common/darwin/Classes/FlutterWebRTCPlugin.m
+++ b/common/darwin/Classes/FlutterWebRTCPlugin.m
@@ -1599,24 +1599,18 @@
 
         if (currentParams != nil) {
             // update values
-            if ([newParams objectForKey:@"active"]) {
-                currentParams.isActive = [[newParams objectForKey:@"active"] boolValue];
-            }
-            if ([newParams objectForKey:@"maxBitrate"]) {
-                currentParams.maxBitrateBps = [newParams objectForKey:@"maxBitrate"];
-            }
-            if ([newParams objectForKey:@"minBitrate"]) {
-                currentParams.minBitrateBps = [newParams objectForKey:@"minBitrate"];
-            }
-            if ([newParams objectForKey:@"maxFramerate"]) {
-                currentParams.maxFramerate = [newParams objectForKey:@"maxFramerate"];
-            }
-            if ([newParams objectForKey:@"numTemporalLayers"]) {
-                currentParams.numTemporalLayers = [newParams objectForKey:@"numTemporalLayers"];
-            }
-            if ([newParams objectForKey:@"scaleResolutionDownBy"]) {
-                currentParams.scaleResolutionDownBy = [newParams objectForKey:@"scaleResolutionDownBy"];
-            }
+            NSNumber *active = [newParams objectForKey:@"active"];
+            if (active != nil) currentParams.isActive = [active boolValue];
+            NSNumber *maxBitrate = [newParams objectForKey:@"maxBitrate"];
+            if (maxBitrate != nil) currentParams.maxBitrateBps = maxBitrate;
+            NSNumber *minBitrate = [newParams objectForKey:@"minBitrate"];
+            if (minBitrate != nil) currentParams.minBitrateBps = minBitrate;
+            NSNumber *maxFramerate = [newParams objectForKey:@"maxFramerate"];
+            if (maxFramerate != nil) currentParams.maxFramerate = maxFramerate;
+            NSNumber *numTemporalLayers = [newParams objectForKey:@"numTemporalLayers"];
+            if (numTemporalLayers != nil) currentParams.numTemporalLayers = numTemporalLayers;
+            NSNumber *scaleResolutionDownBy = [newParams objectForKey:@"scaleResolutionDownBy"];
+            if (scaleResolutionDownBy != nil) currentParams.scaleResolutionDownBy = scaleResolutionDownBy;
         }
     }
 


### PR DESCRIPTION
- `rid` is missing for `rtpParametersToMap` for both iOS, Android.
- higher priority for updating encoding with same rid. (order of array wouldn't matter)
@davidzhao 