### PR TITLE
Properly change 'track' property of RTCRtpSender

### DIFF
--- a/lib/src/native/rtc_peerconnection_impl.dart
+++ b/lib/src/native/rtc_peerconnection_impl.dart
@@ -493,6 +493,11 @@ class RTCPeerConnectionNative extends RTCPeerConnection {
         'senderId': sender.senderId
       });
       bool result = response['result'];
+
+      if (result && (sender is RTCRtpSenderNative)) {
+        sender.removeTrackReference();
+      }
+
       return result;
     } on PlatformException catch (e) {
       throw 'Unable to RTCPeerConnection::removeTrack: ${e.message}';

--- a/lib/src/native/rtc_rtp_sender_impl.dart
+++ b/lib/src/native/rtc_rtp_sender_impl.dart
@@ -87,6 +87,9 @@ class RTCRtpSenderNative extends RTCRtpSender {
         'rtpSenderId': _id,
         'trackId': track.id
       });
+
+      // change reference of associated MediaTrack
+      _track = track;
     } on PlatformException catch (e) {
       throw 'Unable to RTCRtpSender::replaceTrack: ${e.message}';
     }
@@ -102,9 +105,16 @@ class RTCRtpSenderNative extends RTCRtpSender {
         'trackId': track.id,
         'takeOwnership': takeOwnership,
       });
+
+      // change reference of associated MediaTrack
+      _track = track;
     } on PlatformException catch (e) {
       throw 'Unable to RTCRtpSender::setTrack: ${e.message}';
     }
+  }
+
+  void removeTrackReference() {
+    _track = null;
   }
 
   @override
@@ -131,7 +141,7 @@ class RTCRtpSenderNative extends RTCRtpSender {
         'rtpSenderId': _id,
       });
     } on PlatformException catch (e) {
-      throw 'Unable to RTCRtpSender::setTrack: ${e.message}';
+      throw 'Unable to RTCRtpSender::dispose: ${e.message}';
     }
   }
 }


### PR DESCRIPTION
After following APIs are called, the 'track' property of the RTCRtpSender object was not updated. 

- `RTCRtpSender.setTrack()`
- `RTCRtpSender.replaceTrack()`
- `RTCPeerConnection.removeTrack()`

I fixed to correctly update the 'track' property of RTCRtpSender after processing these APIs.