### PR TITLE
chore: Update minSdkVersion to 23 in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ android {
 }
 ```
 
-If necessary, in the same `build.gradle` you will need to increase `minSdkVersion` of `defaultConfig` up to `21` (currently default Flutter generator set it to `16`).
+If necessary, in the same `build.gradle` you will need to increase `minSdkVersion` of `defaultConfig` up to `23` (currently default Flutter generator set it to `16`).
 
 ### Important reminder
 When you compile the release apk, you need to add the following operations,


### PR DESCRIPTION
I think minSdkVersion 23 is correct now, right?