### PR TITLE
Fix type error in data channel event listener

### DIFF
--- a/lib/src/native/rtc_data_channel_impl.dart
+++ b/lib/src/native/rtc_data_channel_impl.dart
@@ -51,7 +51,8 @@ class RTCDataChannelNative extends RTCDataChannel {
     final Map<dynamic, dynamic> map = event;
     switch (map['event']) {
       case 'dataChannelStateChanged':
-        _dataChannelId = int.tryParse(map['id']);
+        _dataChannelId =
+            map['id'] is String ? int.tryParse(map['id']) : map['id'];
         _state = rtcDataChannelStateForString(map['state']);
         onDataChannelState?.call(_state!);
 


### PR DESCRIPTION
Hey $reader,
I just noticed that when I successfully establish a peer connection, I get this error, and tracing it gives me the changes proposed.
The variable `map[id]` is not always a string and that gives the error.

```
E/flutter (21744): [ERROR:flutter/lib/ui/ui_dart_state.cc(209)] Unhandled Exception: type 'int' is not a subtype of type 'String'
E/flutter (21744): #0      RTCDataChannelNative.eventListener
package:flutter_webrtc/…/native/rtc_data_channel_impl.dart:54
E/flutter (21744): #1      _rootRunUnary (dart:async/zone.dart:1436:47)
E/flutter (21744): #2      _CustomZone.runUnary (dart:async/zone.dart:1335:19)
E/flutter (21744): #3      _CustomZone.runUnaryGuarded (dart:async/zone.dart:1244:7)
E/flutter (21744): #4      _BufferingStreamSubscription._sendData (dart:async/stream_impl.dart:341:11)
E/flutter (21744): #5      _DelayedData.perform (dart:async/stream_impl.dart:591:14)
E/flutter (21744): #6      _StreamImplEvents.handleNext (dart:async/stream_impl.dart:706:11)
E/flutter (21744): #7      _PendingEvents.schedule.<anonymous closure> (dart:async/stream_impl.dart:663:7)
E/flutter (21744): #8      _rootRun (dart:async/zone.dart:1420:47)
E/flutter (21744): #9      _CustomZone.run (dart:async/zone.dart:1328:19)
E/flutter (21744): #10     _CustomZone.runGuarded (dart:async/zone.dart:1236:7)
E/flutter (21744): #11     _CustomZone.bindCallbackGuarded.<anonymous closure> (dart:async/zone.dart:1276:23)
E/flutter (21744): #12     _rootRun (dart:async/zone.dart:1428:13)
E/flutter (21744): #13     _CustomZone.run (dart:async/zone.dart:1328:19)
E/flutter (21744): #14     _CustomZone.runGuarded (dart:async/zone.dart:1236:7)
E/flutter (21744): #15     _CustomZone.bindCallbackGuarded.<anonymous closure> (dart:async/zone.dart:1276:23)
E/flutter (21744): #16     _microtaskLoop (dart:async/schedule_microtask.dart:40:21)
E/flutter (21744): #17     _startMicrotaskLoop (dart:async/schedule_microtask.dart:49:5)
```