### PR TITLE
Flutter 3.0 crash fixes

### DIFF
--- a/common/darwin/Classes/FlutterRTCPeerConnection.m
+++ b/common/darwin/Classes/FlutterRTCPeerConnection.m
@@ -504,8 +504,11 @@
 
     dataChannel.eventChannel = eventChannel;
     dataChannel.flutterChannelId = dataChannelId;
-    [eventChannel setStreamHandler:dataChannel];
 
+    dispatch_async(dispatch_get_main_queue(), ^{
+       [eventChannel setStreamHandler:dataChannel];
+    });
+ 
     FlutterEventSink eventSink = peerConnection.eventSink;
     if(eventSink){
         eventSink(@{


### PR DESCRIPTION
setStreamHandler needs to be called on `main` thread.

Calling setStreamHandler from a WebRTC delegate (which is invoked on it's internal thread) causes a thread check failure and crash.
