### PR TITLE
Split data channel's webrtc id from our internal id

### DIFF
--- a/android/src/main/java/com/cloudwebrtc/webrtc/DataChannelObserver.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/DataChannelObserver.java
@@ -12,18 +12,18 @@ import io.flutter.plugin.common.EventChannel;
 
 class DataChannelObserver implements DataChannel.Observer, EventChannel.StreamHandler {
 
-    private final String internalId;
+    private final String flutterId;
     private final DataChannel dataChannel;
 
     private EventChannel eventChannel;
     private EventChannel.EventSink eventSink;
 
-    DataChannelObserver(BinaryMessenger messenger, String peerConnectionId, String internalId,
+    DataChannelObserver(BinaryMessenger messenger, String peerConnectionId, String flutterId,
                         DataChannel dataChannel) {
-        this.internalId = internalId;
+        this.flutterId = flutterId;
         this.dataChannel = dataChannel;
         eventChannel =
-                new EventChannel(messenger, "FlutterWebRTC/dataChannelEvent" + peerConnectionId + internalId);
+                new EventChannel(messenger, "FlutterWebRTC/dataChannelEvent" + peerConnectionId + flutterId);
         eventChannel.setStreamHandler(this);
     }
 

--- a/android/src/main/java/com/cloudwebrtc/webrtc/DataChannelObserver.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/DataChannelObserver.java
@@ -12,18 +12,18 @@ import io.flutter.plugin.common.EventChannel;
 
 class DataChannelObserver implements DataChannel.Observer, EventChannel.StreamHandler {
 
-    private final int mId;
-    private final DataChannel mDataChannel;
+    private final String internalId;
+    private final DataChannel dataChannel;
 
     private EventChannel eventChannel;
     private EventChannel.EventSink eventSink;
 
-    DataChannelObserver(BinaryMessenger messenger, String peerConnectionId, int id,
+    DataChannelObserver(BinaryMessenger messenger, String peerConnectionId, String internalId,
                         DataChannel dataChannel) {
-        mId = id;
-        mDataChannel = dataChannel;
+        this.internalId = internalId;
+        this.dataChannel = dataChannel;
         eventChannel =
-                new EventChannel(messenger, "FlutterWebRTC/dataChannelEvent" + peerConnectionId + id);
+                new EventChannel(messenger, "FlutterWebRTC/dataChannelEvent" + peerConnectionId + internalId);
         eventChannel.setStreamHandler(this);
     }
 
@@ -59,8 +59,8 @@ class DataChannelObserver implements DataChannel.Observer, EventChannel.StreamHa
     public void onStateChange() {
         ConstraintsMap params = new ConstraintsMap();
         params.putString("event", "dataChannelStateChanged");
-        params.putInt("id", mDataChannel.id());
-        params.putString("state", dataChannelStateString(mDataChannel.state()));
+        params.putInt("id", dataChannel.id());
+        params.putString("state", dataChannelStateString(dataChannel.state()));
         sendEvent(params);
     }
 
@@ -68,7 +68,7 @@ class DataChannelObserver implements DataChannel.Observer, EventChannel.StreamHa
     public void onMessage(DataChannel.Buffer buffer) {
         ConstraintsMap params = new ConstraintsMap();
         params.putString("event", "dataChannelReceiveMessage");
-        params.putInt("id", mDataChannel.id());
+        params.putInt("id", dataChannel.id());
 
         byte[] bytes;
         if (buffer.data.hasArray()) {

--- a/android/src/main/java/com/cloudwebrtc/webrtc/MethodCallHandlerImpl.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/MethodCallHandlerImpl.java
@@ -310,7 +310,7 @@ public class MethodCallHandlerImpl implements MethodCallHandler, StateProvider {
       }
       case "dataChannelSend": {
         String peerConnectionId = call.argument("peerConnectionId");
-        int dataChannelId = call.argument("dataChannelId");
+        String dataChannelId = call.argument("dataChannelId");
         String type = call.argument("type");
         Boolean isBinary = type.equals("binary");
         ByteBuffer byteBuffer;
@@ -331,7 +331,7 @@ public class MethodCallHandlerImpl implements MethodCallHandler, StateProvider {
       }
       case "dataChannelClose": {
         String peerConnectionId = call.argument("peerConnectionId");
-        int dataChannelId = call.argument("dataChannelId");
+        String dataChannelId = call.argument("dataChannelId");
         dataChannelClose(peerConnectionId, dataChannelId);
         result.success(null);
         break;
@@ -1549,7 +1549,7 @@ public class MethodCallHandlerImpl implements MethodCallHandler, StateProvider {
     }
   }
 
-  public void dataChannelSend(String peerConnectionId, int dataChannelId, ByteBuffer bytebuffer,
+  public void dataChannelSend(String peerConnectionId, String dataChannelId, ByteBuffer bytebuffer,
                               Boolean isBinary) {
     // Forward to PeerConnectionObserver which deals with DataChannels
     // because DataChannel is owned by PeerConnection.
@@ -1562,7 +1562,7 @@ public class MethodCallHandlerImpl implements MethodCallHandler, StateProvider {
     }
   }
 
-  public void dataChannelClose(String peerConnectionId, int dataChannelId) {
+  public void dataChannelClose(String peerConnectionId, String dataChannelId) {
     // Forward to PeerConnectionObserver which deals with DataChannels
     // because DataChannel is owned by PeerConnection.
     PeerConnectionObserver pco

--- a/android/src/main/java/com/cloudwebrtc/webrtc/PeerConnectionObserver.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/PeerConnectionObserver.java
@@ -16,6 +16,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.List;
+import java.util.UUID;
 import org.webrtc.AudioTrack;
 import org.webrtc.CandidatePairChangeEvent;
 import org.webrtc.DataChannel;
@@ -34,7 +35,7 @@ import org.webrtc.VideoTrack;
 
 class PeerConnectionObserver implements PeerConnection.Observer, EventChannel.StreamHandler {
   private final static String TAG = FlutterWebRTCPlugin.TAG;
-  private final SparseArray<DataChannel> dataChannels = new SparseArray<>();
+  private final Map<String, DataChannel> dataChannels = new HashMap<>();
   private BinaryMessenger messenger;
   private final String id;
   private PeerConnection peerConnection;
@@ -121,21 +122,22 @@ class PeerConnectionObserver implements PeerConnection.Observer, EventChannel.St
     // been deprecated in Chromium, and Google have decided (in 2015) to no
     // longer support them (in the face of multiple reported issues of
     // breakages).
-    int dataChannelId = init.id;
-    if (dataChannel != null && -1 != dataChannelId) {
-        dataChannels.put(dataChannelId, dataChannel);
-        registerDataChannelObserver(dataChannelId, dataChannel);
+    String internalId = getNextDataChannelUUID();
+    if (dataChannel != null) {
+        dataChannels.put(internalId, dataChannel);
+        registerDataChannelObserver(internalId, dataChannel);
 
         ConstraintsMap params = new ConstraintsMap();
-        params.putInt("id", dataChannelId);
+        params.putInt("id", dataChannel.id());
         params.putString("label", dataChannel.label());
+        params.putString("internalId", internalId);
         result.success(params.toMap());
     } else {
-        resultError("createDataChannel", "Can't create data-channel for id: " + dataChannelId, result);
+        resultError("createDataChannel", "Can't create data-channel for id: " + init.id, result);
     }
   }
 
-    void dataChannelClose(int dataChannelId) {
+    void dataChannelClose(String dataChannelId) {
         DataChannel dataChannel = dataChannels.get(dataChannelId);
         if (dataChannel != null) {
             dataChannel.close();
@@ -145,7 +147,7 @@ class PeerConnectionObserver implements PeerConnection.Observer, EventChannel.St
         }
     }
 
-    void dataChannelSend(int dataChannelId, ByteBuffer byteBuffer, Boolean isBinary) {
+    void dataChannelSend(String dataChannelId, ByteBuffer byteBuffer, Boolean isBinary) {
         DataChannel dataChannel = dataChannels.get(dataChannelId);
         if (dataChannel != null) {
             DataChannel.Buffer buffer = new DataChannel.Buffer(byteBuffer, isBinary);
@@ -478,41 +480,20 @@ class PeerConnectionObserver implements PeerConnection.Observer, EventChannel.St
 
     @Override
   public void onDataChannel(DataChannel dataChannel) {
-    // XXX Unfortunately, the Java WebRTC API doesn't expose the id
-    // of the underlying C++/native DataChannel (even though the
-    // WebRTC standard defines the DataChannel.id property). As a
-    // workaround, generated an id which will surely not clash with
-    // the ids of the remotely-opened (and standard-compliant
-    // locally-opened) DataChannels.
-    int dataChannelId = -1;
-    // The RTCDataChannel.id space is limited to unsigned short by
-    // the standard:
-    // https://www.w3.org/TR/webrtc/#dom-datachannel-id.
-    // Additionally, 65535 is reserved due to SCTP INIT and
-    // INIT-ACK chunks only allowing a maximum of 65535 streams to
-    // be negotiated (as defined by the WebRTC Data Channel
-    // Establishment Protocol).
-    for (int i = 65536; i <= Integer.MAX_VALUE; ++i) {
-      if (null == dataChannels.get(i, null)) {
-        dataChannelId = i;
-        break;
-      }
-    }
-    if (-1 == dataChannelId) {
-      return;
-    }
+    String internalId = getNextDataChannelUUID();
     ConstraintsMap params = new ConstraintsMap();
     params.putString("event", "didOpenDataChannel");
-    params.putInt("id", dataChannelId);
+    params.putInt("id", dataChannel.id());
     params.putString("label", dataChannel.label());
+    params.putString("internalId", internalId);
 
-    dataChannels.put(dataChannelId, dataChannel);
-    registerDataChannelObserver(dataChannelId, dataChannel);
+    dataChannels.put(internalId, dataChannel);
+    registerDataChannelObserver(internalId, dataChannel);
 
     sendEvent(params);
   }
 
-  private void registerDataChannelObserver(int dcId, DataChannel dataChannel) {
+  private void registerDataChannelObserver(String dcId, DataChannel dataChannel) {
     // DataChannel.registerObserver implementation does not allow to
     // unregister, so the observer is registered here and is never
     // unregistered
@@ -1108,4 +1089,14 @@ private RtpParameters updateRtpParameters(RtpParameters parameters, Map<String, 
         return track;
     }
 
+    public String getNextDataChannelUUID() {
+      String uuid;
+  
+      do {
+        uuid = UUID.randomUUID().toString();
+      } while (dataChannels.get(uuid) != null);
+  
+      return uuid;
+    }
+  
 }

--- a/android/src/main/java/com/cloudwebrtc/webrtc/PeerConnectionObserver.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/PeerConnectionObserver.java
@@ -122,15 +122,15 @@ class PeerConnectionObserver implements PeerConnection.Observer, EventChannel.St
     // been deprecated in Chromium, and Google have decided (in 2015) to no
     // longer support them (in the face of multiple reported issues of
     // breakages).
-    String internalId = getNextDataChannelUUID();
+    String flutterId = getNextDataChannelUUID();
     if (dataChannel != null) {
-        dataChannels.put(internalId, dataChannel);
-        registerDataChannelObserver(internalId, dataChannel);
+        dataChannels.put(flutterId, dataChannel);
+        registerDataChannelObserver(flutterId, dataChannel);
 
         ConstraintsMap params = new ConstraintsMap();
         params.putInt("id", dataChannel.id());
         params.putString("label", dataChannel.label());
-        params.putString("internalId", internalId);
+        params.putString("flutterId", flutterId);
         result.success(params.toMap());
     } else {
         resultError("createDataChannel", "Can't create data-channel for id: " + init.id, result);
@@ -480,15 +480,15 @@ class PeerConnectionObserver implements PeerConnection.Observer, EventChannel.St
 
     @Override
   public void onDataChannel(DataChannel dataChannel) {
-    String internalId = getNextDataChannelUUID();
+    String flutterId = getNextDataChannelUUID();
     ConstraintsMap params = new ConstraintsMap();
     params.putString("event", "didOpenDataChannel");
     params.putInt("id", dataChannel.id());
     params.putString("label", dataChannel.label());
-    params.putString("internalId", internalId);
+    params.putString("flutterId", flutterId);
 
-    dataChannels.put(internalId, dataChannel);
-    registerDataChannelObserver(internalId, dataChannel);
+    dataChannels.put(flutterId, dataChannel);
+    registerDataChannelObserver(flutterId, dataChannel);
 
     sendEvent(params);
   }

--- a/common/cpp/include/flutter_data_channel.h
+++ b/common/cpp/include/flutter_data_channel.h
@@ -41,7 +41,7 @@ class FlutterDataChannel {
   void DataChannelClose(RTCDataChannel *data_channel,
                         std::unique_ptr<MethodResult<EncodableValue>>);
 
-  RTCDataChannel *DataChannelFormId(int id);
+  RTCDataChannel *DataChannelForId(const std::string &id);
 
  private:
   FlutterWebRTCBase *base_;

--- a/common/cpp/include/flutter_data_channel.h
+++ b/common/cpp/include/flutter_data_channel.h
@@ -39,6 +39,7 @@ class FlutterDataChannel {
                        std::unique_ptr<MethodResult<EncodableValue>>);
 
   void DataChannelClose(RTCDataChannel *data_channel,
+                        const std::string &data_channel_uuid,
                         std::unique_ptr<MethodResult<EncodableValue>>);
 
   RTCDataChannel *DataChannelForId(const std::string &id);

--- a/common/cpp/include/flutter_webrtc_base.h
+++ b/common/cpp/include/flutter_webrtc_base.h
@@ -168,9 +168,8 @@ class FlutterWebRTCBase {
   std::map<std::string, scoped_refptr<RTCPeerConnection>> peerconnections_;
   std::map<std::string, scoped_refptr<RTCMediaStream>> local_streams_;
   std::map<std::string, scoped_refptr<RTCMediaTrack>> local_tracks_;
-  std::map<std::string, scoped_refptr<RTCDataChannel>> data_channels_;
   std::map<int64_t, std::shared_ptr<FlutterVideoRenderer>> renders_;
-  std::map<int, std::shared_ptr<FlutterRTCDataChannelObserver>>
+  std::map<std::string, std::shared_ptr<FlutterRTCDataChannelObserver>>
       data_channel_observers_;
   std::map<std::string, std::shared_ptr<FlutterPeerConnectionObserver>>
       peerconnection_observers_;

--- a/common/cpp/src/flutter_data_channel.cc
+++ b/common/cpp/src/flutter_data_channel.cc
@@ -39,20 +39,6 @@ void FlutterDataChannel::CreateDataChannel(
 
   RTCDataChannelInit init;
   init.id = GetValue<int>(dataChannelDict.find(EncodableValue("id"))->second);
-
-  base_->lock();
-  if (base_->data_channel_observers_.find( init.id) !=
-      base_->data_channel_observers_.end()) {
-    for(int i = 1024; i < 65535; i++){
-      if(base_->data_channel_observers_.find(i) ==
-      base_->data_channel_observers_.end()){
-         init.id = i;
-        break;
-      }
-    }
-  }
-  base_->unlock();
-
   init.ordered =
       GetValue<bool>(dataChannelDict.find(EncodableValue("ordered"))->second);
 
@@ -77,21 +63,22 @@ void FlutterDataChannel::CreateDataChannel(
   scoped_refptr<RTCDataChannel> data_channel =
       pc->CreateDataChannel(label.c_str(), &init);
 
-
+  std::string uuid = base_->GenerateUUID();
   std::string event_channel = "FlutterWebRTC/dataChannelEvent" +
-                              peerConnectionId + std::to_string(init.id);
+                              peerConnectionId + uuid;
 
   std::unique_ptr<FlutterRTCDataChannelObserver> observer(
       new FlutterRTCDataChannelObserver(data_channel, base_->messenger_,
                                         event_channel));
 
   base_->lock();
-  base_->data_channel_observers_[init.id] = std::move(observer);
+  base_->data_channel_observers_[uuid] = std::move(observer);
   base_->unlock();
 
   EncodableMap params;
   params[EncodableValue("id")] = EncodableValue(init.id);
   params[EncodableValue("label")] = EncodableValue(data_channel->label().std_string());
+  params[EncodableValue("flutterId")] = EncodableValue(uuid);
   result->Success(EncodableValue(params));
 }
 
@@ -112,17 +99,18 @@ void FlutterDataChannel::DataChannelSend(
 
 void FlutterDataChannel::DataChannelClose(
     RTCDataChannel *data_channel,
+    const std::string &data_channel_uuid,
     std::unique_ptr<MethodResult<EncodableValue>> result) {
   int id = data_channel->id();
   data_channel->Close();
-  auto it = base_->data_channel_observers_.find(id);
+  auto it = base_->data_channel_observers_.find(data_channel_uuid);
   if (it != base_->data_channel_observers_.end())
     base_->data_channel_observers_.erase(it);
   result->Success();
 }
 
-RTCDataChannel *FlutterDataChannel::DataChannelFormId(int id) {
-  auto it = base_->data_channel_observers_.find(id);
+RTCDataChannel *FlutterDataChannel::DataChannelForId(const std::string &uuid) {
+  auto it = base_->data_channel_observers_.find(uuid);
 
   if (it != base_->data_channel_observers_.end()) {
     FlutterRTCDataChannelObserver *observer = it->second.get();

--- a/common/cpp/src/flutter_data_channel.cc
+++ b/common/cpp/src/flutter_data_channel.cc
@@ -101,7 +101,6 @@ void FlutterDataChannel::DataChannelClose(
     RTCDataChannel *data_channel,
     const std::string &data_channel_uuid,
     std::unique_ptr<MethodResult<EncodableValue>> result) {
-  int id = data_channel->id();
   data_channel->Close();
   auto it = base_->data_channel_observers_.find(data_channel_uuid);
   if (it != base_->data_channel_observers_.end())

--- a/common/cpp/src/flutter_webrtc.cc
+++ b/common/cpp/src/flutter_webrtc.cc
@@ -239,7 +239,7 @@ void FlutterWebRTC::HandleMethodCall(
       return;
     }
 
-    int dataChannelId = findString(params, "dataChannelId");
+    const std::string dataChannelId = findString(params, "dataChannelId");
     const std::string type = findString(params, "type");
     const EncodableValue data = findEncodableValue(params, "data");
     RTCDataChannel* data_channel = DataChannelForId(dataChannelId);
@@ -264,14 +264,14 @@ void FlutterWebRTC::HandleMethodCall(
       return;
     }
 
-    int dataChannelId = findString(params, "dataChannelId");
+    const std::string dataChannelId = findString(params, "dataChannelId");
     RTCDataChannel* data_channel = DataChannelForId(dataChannelId);
     if (data_channel == nullptr) {
       result->Error("dataChannelCloseFailed",
                     "dataChannelClose() data_channel is null");
       return;
     }
-    DataChannelClose(data_channel, std::move(result));
+    DataChannelClose(data_channel, dataChannelId, std::move(result));
   } else if (method_call.method_name().compare("streamDispose") == 0) {
     if (!method_call.arguments()) {
       result->Error("Bad Arguments", "Null constraints arguments received");

--- a/common/cpp/src/flutter_webrtc.cc
+++ b/common/cpp/src/flutter_webrtc.cc
@@ -239,10 +239,10 @@ void FlutterWebRTC::HandleMethodCall(
       return;
     }
 
-    int dataChannelId = findInt(params, "dataChannelId");
+    int dataChannelId = findString(params, "dataChannelId");
     const std::string type = findString(params, "type");
     const EncodableValue data = findEncodableValue(params, "data");
-    RTCDataChannel* data_channel = DataChannelFormId(dataChannelId);
+    RTCDataChannel* data_channel = DataChannelForId(dataChannelId);
     if (data_channel == nullptr) {
       result->Error("dataChannelSendFailed",
                     "dataChannelSend() data_channel is null");
@@ -264,8 +264,8 @@ void FlutterWebRTC::HandleMethodCall(
       return;
     }
 
-    int dataChannelId = findInt(params, "dataChannelId");
-    RTCDataChannel* data_channel = DataChannelFormId(dataChannelId);
+    int dataChannelId = findString(params, "dataChannelId");
+    RTCDataChannel* data_channel = DataChannelForId(dataChannelId);
     if (data_channel == nullptr) {
       result->Error("dataChannelCloseFailed",
                     "dataChannelClose() data_channel is null");

--- a/common/darwin/Classes/FlutterRTCDataChannel.h
+++ b/common/darwin/Classes/FlutterRTCDataChannel.h
@@ -3,7 +3,7 @@
 
 @interface RTCDataChannel (Flutter) <FlutterStreamHandler>
 @property (nonatomic, strong, nonnull) NSString *peerConnectionId;
-@property (nonatomic, strong, nonnull) NSNumber *flutterChannelId;
+@property (nonatomic, strong, nonnull) NSString *flutterChannelId;
 @property (nonatomic, strong, nullable) FlutterEventSink eventSink;
 @property (nonatomic, strong, nullable) FlutterEventChannel *eventChannel;
 @end

--- a/common/darwin/Classes/FlutterRTCDataChannel.m
+++ b/common/darwin/Classes/FlutterRTCDataChannel.m
@@ -72,19 +72,19 @@
     
     if (nil != dataChannel) {
         dataChannel.peerConnectionId = peerConnectionId;
-        NSNumber *dataChannelId = [NSNumber numberWithInteger:config.channelId];
-        peerConnection.dataChannels[dataChannelId] = dataChannel;
-        dataChannel.flutterChannelId = dataChannelId;
+        NSString *flutterId = [[NSUUID UUID] UUIDString];
+        peerConnection.dataChannels[flutterId] = dataChannel;
+        dataChannel.flutterChannelId = flutterId;
         dataChannel.delegate = self;
         
         FlutterEventChannel *eventChannel = [FlutterEventChannel
-                                             eventChannelWithName:[NSString stringWithFormat:@"FlutterWebRTC/dataChannelEvent%1$@%2$d", peerConnectionId, [dataChannelId intValue]]
+                                             eventChannelWithName:[NSString stringWithFormat:@"FlutterWebRTC/dataChannelEvent%1$@%2$@", peerConnectionId, flutterId]
                                              binaryMessenger:messenger];
         
         dataChannel.eventChannel = eventChannel;
         [eventChannel setStreamHandler:dataChannel];
         
-        result(@{@"label": label, @"id": dataChannelId});
+        result(@{@"label": label, @"id": [NSNumber numberWithInt:dataChannel.channelId], @"flutterId": flutterId});
     }
 }
 
@@ -102,7 +102,7 @@
 }
 
 -(void)dataChannelSend:(nonnull NSString *)peerConnectionId
-                    dataChannelId:(nonnull NSNumber *)dataChannelId
+                    dataChannelId:(nonnull NSString *)dataChannelId
                              data:(id)data
                              type:(NSString *)type
 {
@@ -136,7 +136,7 @@
     FlutterEventSink eventSink = channel.eventSink;
     if(eventSink) {
         eventSink(@{ @"event" : @"dataChannelStateChanged",
-                     @"id": channel.flutterChannelId,
+                     @"id": [NSNumber numberWithInt:channel.channelId],
                      @"state": [self stringForDataChannelState:channel.readyState]});
     }
 }
@@ -158,7 +158,7 @@
     FlutterEventSink eventSink = channel.eventSink;
     if(eventSink) {
         eventSink(@{ @"event" : @"dataChannelReceiveMessage",
-                     @"id": channel.flutterChannelId,
+                     @"id": [NSNumber numberWithInt:channel.channelId],
                      @"type": type,
                      @"data": (data ? data : [NSNull null])});
     }

--- a/common/darwin/Classes/FlutterRTCPeerConnection.h
+++ b/common/darwin/Classes/FlutterRTCPeerConnection.h
@@ -1,7 +1,7 @@
 #import "FlutterWebRTCPlugin.h"
 
 @interface RTCPeerConnection (Flutter) <FlutterStreamHandler>
-@property (nonatomic, strong, nonnull) NSMutableDictionary<NSNumber *, RTCDataChannel *> *dataChannels;
+@property (nonatomic, strong, nonnull) NSMutableDictionary<NSString *, RTCDataChannel *> *dataChannels;
 @property (nonatomic, strong, nonnull) NSMutableDictionary<NSString *, RTCMediaStream *> *remoteStreams;
 @property (nonatomic, strong, nonnull) NSMutableDictionary<NSString *, RTCMediaStreamTrack *> *remoteTracks;
 @property (nonatomic, strong, nonnull) NSString *flutterId;

--- a/common/darwin/Classes/FlutterWebRTCPlugin.m
+++ b/common/darwin/Classes/FlutterWebRTCPlugin.m
@@ -339,7 +339,7 @@
     } else if ([@"dataChannelSend" isEqualToString:call.method]){
         NSDictionary* argsMap = call.arguments;
         NSString* peerConnectionId = argsMap[@"peerConnectionId"];
-        NSNumber* dataChannelId = argsMap[@"dataChannelId"];
+        NSString* dataChannelId = argsMap[@"dataChannelId"];
         NSString* type = argsMap[@"type"];
         id data = argsMap[@"data"];
 

--- a/lib/src/native/rtc_data_channel_impl.dart
+++ b/lib/src/native/rtc_data_channel_impl.dart
@@ -15,18 +15,18 @@ final _typeStringToMessageType = <String, MessageType>{
 /// Can send and receive text and binary messages.
 class RTCDataChannelNative extends RTCDataChannel {
   RTCDataChannelNative(this._peerConnectionId, this._label, this._dataChannelId,
-      this._internalId) {
+      this._flutterId) {
     stateChangeStream = _stateChangeController.stream;
     messageStream = _messageController.stream;
-    _eventSubscription = _eventChannelFor(_peerConnectionId, _internalId)
+    _eventSubscription = _eventChannelFor(_peerConnectionId, _flutterId)
         .receiveBroadcastStream()
         .listen(eventListener, onError: errorListener);
   }
   final String _peerConnectionId;
   final String _label;
 
-  /// Id for the datachannel in the intermediate layer.
-  final String _internalId;
+  /// Id for the datachannel in the Flutter <-> Native layer.
+  final String _flutterId;
 
   int? _dataChannelId;
   RTCDataChannelState? _state;
@@ -80,9 +80,9 @@ class RTCDataChannelNative extends RTCDataChannel {
     }
   }
 
-  EventChannel _eventChannelFor(String peerConnectionId, String internalId) {
+  EventChannel _eventChannelFor(String peerConnectionId, String flutterId) {
     return EventChannel(
-        'FlutterWebRTC/dataChannelEvent$peerConnectionId$internalId');
+        'FlutterWebRTC/dataChannelEvent$peerConnectionId$flutterId');
   }
 
   void errorListener(Object obj) {
@@ -95,7 +95,7 @@ class RTCDataChannelNative extends RTCDataChannel {
   Future<void> send(RTCDataChannelMessage message) async {
     await WebRTC.invokeMethod('dataChannelSend', <String, dynamic>{
       'peerConnectionId': _peerConnectionId,
-      'dataChannelId': _internalId,
+      'dataChannelId': _flutterId,
       'type': message.isBinary ? 'binary' : 'text',
       'data': message.isBinary ? message.binary : message.text,
     });
@@ -108,7 +108,7 @@ class RTCDataChannelNative extends RTCDataChannel {
     await _eventSubscription?.cancel();
     await WebRTC.invokeMethod('dataChannelClose', <String, dynamic>{
       'peerConnectionId': _peerConnectionId,
-      'dataChannelId': _internalId
+      'dataChannelId': _flutterId
     });
   }
 }

--- a/lib/src/native/rtc_data_channel_impl.dart
+++ b/lib/src/native/rtc_data_channel_impl.dart
@@ -14,16 +14,20 @@ final _typeStringToMessageType = <String, MessageType>{
 /// A class that represents a WebRTC datachannel.
 /// Can send and receive text and binary messages.
 class RTCDataChannelNative extends RTCDataChannel {
-  RTCDataChannelNative(
-      this._peerConnectionId, this._label, this._dataChannelId) {
+  RTCDataChannelNative(this._peerConnectionId, this._label, this._dataChannelId,
+      this._internalId) {
     stateChangeStream = _stateChangeController.stream;
     messageStream = _messageController.stream;
-    _eventSubscription = _eventChannelFor(_peerConnectionId, _dataChannelId)
+    _eventSubscription = _eventChannelFor(_peerConnectionId, _internalId)
         .receiveBroadcastStream()
         .listen(eventListener, onError: errorListener);
   }
   final String _peerConnectionId;
   final String _label;
+
+  /// Id for the datachannel in the intermediate layer.
+  final String _internalId;
+
   int? _dataChannelId;
   RTCDataChannelState? _state;
   StreamSubscription<dynamic>? _eventSubscription;
@@ -58,7 +62,7 @@ class RTCDataChannelNative extends RTCDataChannel {
         _stateChangeController.add(_state!);
         break;
       case 'dataChannelReceiveMessage':
-        //int dataChannelId = map['id'];
+        _dataChannelId = map['id'];
 
         var type = _typeStringToMessageType[map['type']];
         dynamic data = map['data'];
@@ -76,9 +80,9 @@ class RTCDataChannelNative extends RTCDataChannel {
     }
   }
 
-  EventChannel _eventChannelFor(String peerConnectionId, int? dataChannelId) {
+  EventChannel _eventChannelFor(String peerConnectionId, String internalId) {
     return EventChannel(
-        'FlutterWebRTC/dataChannelEvent$peerConnectionId$dataChannelId');
+        'FlutterWebRTC/dataChannelEvent$peerConnectionId$internalId');
   }
 
   void errorListener(Object obj) {
@@ -91,7 +95,7 @@ class RTCDataChannelNative extends RTCDataChannel {
   Future<void> send(RTCDataChannelMessage message) async {
     await WebRTC.invokeMethod('dataChannelSend', <String, dynamic>{
       'peerConnectionId': _peerConnectionId,
-      'dataChannelId': _dataChannelId,
+      'dataChannelId': _internalId,
       'type': message.isBinary ? 'binary' : 'text',
       'data': message.isBinary ? message.binary : message.text,
     });
@@ -104,7 +108,7 @@ class RTCDataChannelNative extends RTCDataChannel {
     await _eventSubscription?.cancel();
     await WebRTC.invokeMethod('dataChannelClose', <String, dynamic>{
       'peerConnectionId': _peerConnectionId,
-      'dataChannelId': _dataChannelId
+      'dataChannelId': _internalId
     });
   }
 }

--- a/lib/src/native/rtc_peerconnection_impl.dart
+++ b/lib/src/native/rtc_peerconnection_impl.dart
@@ -155,9 +155,9 @@ class RTCPeerConnectionNative extends RTCPeerConnection {
       case 'didOpenDataChannel':
         int dataChannelId = map['id'];
         String label = map['label'];
-        String internalId = map['internalId'];
+        String flutterId = map['flutterId'];
         _dataChannel = RTCDataChannelNative(
-            _peerConnectionId, label, dataChannelId, internalId);
+            _peerConnectionId, label, dataChannelId, flutterId);
         onDataChannel?.call(_dataChannel!);
         break;
       case 'onRenegotiationNeeded':
@@ -409,7 +409,7 @@ class RTCPeerConnectionNative extends RTCPeerConnection {
       });
 
       _dataChannel = RTCDataChannelNative(
-          _peerConnectionId, label, response['id'], response['internalId']);
+          _peerConnectionId, label, response['id'], response['flutterId']);
       return _dataChannel!;
     } on PlatformException catch (e) {
       throw 'Unable to RTCPeerConnection::createDataChannel: ${e.message}';

--- a/lib/src/native/rtc_peerconnection_impl.dart
+++ b/lib/src/native/rtc_peerconnection_impl.dart
@@ -155,8 +155,9 @@ class RTCPeerConnectionNative extends RTCPeerConnection {
       case 'didOpenDataChannel':
         int dataChannelId = map['id'];
         String label = map['label'];
-        _dataChannel =
-            RTCDataChannelNative(_peerConnectionId, label, dataChannelId);
+        String internalId = map['internalId'];
+        _dataChannel = RTCDataChannelNative(
+            _peerConnectionId, label, dataChannelId, internalId);
         onDataChannel?.call(_dataChannel!);
         break;
       case 'onRenegotiationNeeded':
@@ -407,8 +408,8 @@ class RTCPeerConnectionNative extends RTCPeerConnection {
         'dataChannelDict': dataChannelDict.toMap()
       });
 
-      _dataChannel =
-          RTCDataChannelNative(_peerConnectionId, label, response['id']);
+      _dataChannel = RTCDataChannelNative(
+          _peerConnectionId, label, response['id'], response['internalId']);
       return _dataChannel!;
     } on PlatformException catch (e) {
       throw 'Unable to RTCPeerConnection::createDataChannel: ${e.message}';

--- a/test/unit/rtc_peerconnection_test.dart
+++ b/test/unit/rtc_peerconnection_test.dart
@@ -45,6 +45,7 @@ void main() {
       channel.eventListener(<String, dynamic>{
         'event': 'dataChannelStateChanged',
         'id': 0,
+        'flutterId': '',
         'state': 'open'
       });
     };
@@ -76,6 +77,7 @@ void main() {
         },
         'id': 0,
         'label': '',
+        'flutterId': '',
       });
     });
   });


### PR DESCRIPTION
We're using the data channel id as our internal id, but those ids may change if they get negotiated in-band, and causes issues locating the data channel. This PR creates a separate immutable id for our mappings.