### PR TITLE
Fixes DataChannel issue described in #974

### DIFF
--- a/common/darwin/Classes/FlutterRTCPeerConnection.m
+++ b/common/darwin/Classes/FlutterRTCPeerConnection.m
@@ -506,19 +506,18 @@
     dataChannel.eventChannel = eventChannel;
     dataChannel.flutterChannelId = flutterChannelId;
 
-    FlutterEventSink eventSink = peerConnection.eventSink;
-    if(eventSink){
-        eventSink(@{
-                    @"event" : @"didOpenDataChannel",
-                    @"id": dataChannelId,
-                    @"label": dataChannel.label,
-                    @"flutterId": flutterChannelId
-                    });
-    }
-
     dispatch_async(dispatch_get_main_queue(), ^{
        // setStreamHandler on main thread
        [eventChannel setStreamHandler:dataChannel];
+       FlutterEventSink eventSink = peerConnection.eventSink;
+       if(eventSink){
+           eventSink(@{
+                       @"event" : @"didOpenDataChannel",
+                       @"id": dataChannelId,
+                       @"label": dataChannel.label,
+                       @"flutterId": flutterChannelId
+                       });
+       }
     });
 }
 


### PR DESCRIPTION
Previously it was possible that the data channel on the dart side would be created before event channel was ready. This moves event sink lower and is triggered in main thread.