### PR TITLE
Fix variant exception of findLongInt.

### DIFF
--- a/common/cpp/include/flutter_webrtc_base.h
+++ b/common/cpp/include/flutter_webrtc_base.h
@@ -86,9 +86,13 @@ inline int findInt(const EncodableMap& map, const std::string& key) {
 
 inline int64_t findLongInt(const EncodableMap& map, const std::string& key) {
   for (auto it : map) {
-    if (key == GetValue<std::string>(it.first) &&
-        (TypeIs<int64_t>(it.second) || TypeIs<int32_t>(it.second)))
-      return GetValue<int64_t>(it.second);
+    if (key == GetValue<std::string>(it.first)) {
+      if (TypeIs<int64_t>(it.second)) {
+        return GetValue<int64_t>(it.second);
+      } else if (TypeIs<int32_t>(it.second)) {
+        return GetValue<int32_t>(it.second);
+      }
+    }
   }
 
   return -1;


### PR DESCRIPTION
If the EncodableValue is int32_t, findLongInt will throw a std::bad_variant_access exception.
Please refer to https://github.com/flutter-webrtc/flutter-webrtc/issues/989