### PR TITLE
fix: Fix compile warning for Darwin.

### DIFF
--- a/common/darwin/Classes/FlutterRTCDataChannel.h
+++ b/common/darwin/Classes/FlutterRTCDataChannel.h
@@ -22,7 +22,7 @@
 
 
 -(void)dataChannelSend:(nonnull NSString *)peerConnectionId
-         dataChannelId:(nonnull NSNumber *)dataChannelId
+         dataChannelId:(nonnull NSString *)dataChannelId
                   data:(nonnull NSString *)data
                   type:(nonnull NSString *)type;
 

--- a/common/darwin/Classes/FlutterRTCDesktopCapturer.m
+++ b/common/darwin/Classes/FlutterRTCDesktopCapturer.m
@@ -23,6 +23,7 @@ NSArray<RTCDesktopSource *>* _captureSources;
     NSString *mediaStreamId = [[NSUUID UUID] UUIDString];
     RTCMediaStream *mediaStream = [self.peerConnectionFactory mediaStreamWithStreamId:mediaStreamId];
     RTCVideoSource *videoSource = [self.peerConnectionFactory videoSource];
+    NSString *trackUUID = [[NSUUID UUID] UUIDString];
 
 #if TARGET_OS_IPHONE
  BOOL useBroadcastExtension = false;
@@ -43,8 +44,8 @@ NSArray<RTCDesktopSource *>* _captureSources;
     [screenCapturer startCapture];
     NSLog(@"start %@ capture", useBroadcastExtension ? @"broadcast" : @"replykit");
         
-    self.videoCapturerStopHandlers[mediaStreamId] = ^(CompletionHandler handler) {
-        NSLog(@"stop %@ capture", useBroadcastExtension ? @"broadcast" : @"replykit");
+    self.videoCapturerStopHandlers[trackUUID] = ^(CompletionHandler handler) {
+        NSLog(@"stop %@ capture, trackID %@", useBroadcastExtension ? @"broadcast" : @"replykit", trackUUID);
         [screenCapturer stopCaptureWithCompletionHandler:handler];
     };
 
@@ -118,14 +119,13 @@ NSArray<RTCDesktopSource *>* _captureSources;
     [desktopCapturer startCaptureWithFPS:fps];
     NSLog(@"start desktop capture: sourceId: %@, type: %@, fps: %lu", sourceId, source.sourceType == RTCDesktopSourceTypeScreen ? @"screen" : @"window", fps);
 
-    self.videoCapturerStopHandlers[mediaStreamId] = ^(CompletionHandler handler) {
-        NSLog(@"stop desktop capture: sourceId: %@, type: %@", sourceId, source.sourceType == RTCDesktopSourceTypeScreen ? @"screen" : @"window");
+    self.videoCapturerStopHandlers[trackUUID] = ^(CompletionHandler handler) {
+        NSLog(@"stop desktop capture: sourceId: %@, type: %@, trackID %@", sourceId, source.sourceType == RTCDesktopSourceTypeScreen ? @"screen" : @"window", trackUUID);
         [desktopCapturer stopCapture];
         handler();
     };
 #endif
 
-    NSString *trackUUID = [[NSUUID UUID] UUIDString];
     RTCVideoTrack *videoTrack = [self.peerConnectionFactory videoTrackWithSource:videoSource trackId:trackUUID];
     [mediaStream addVideoTrack:videoTrack];
 

--- a/common/darwin/Classes/FlutterRTCMediaStream.m
+++ b/common/darwin/Classes/FlutterRTCMediaStream.m
@@ -353,13 +353,15 @@ typedef void (^NavigatorUserMediaSuccessCallback)(RTCMediaStream *mediaStream);
                 NSLog(@"Start capture error: %@", [error localizedDescription]);
             }
         }];
-        __weak RTCCameraVideoCapturer* capturer = self.videoCapturer;
-        self.videoCapturerStopHandlers[mediaStream.streamId] = ^(CompletionHandler handler) {
-            NSLog(@"Stop video capturer");
-            [capturer stopCaptureWithCompletionHandler:handler];
-        };
         NSString *trackUUID = [[NSUUID UUID] UUIDString];
         RTCVideoTrack *videoTrack = [self.peerConnectionFactory videoTrackWithSource:videoSource trackId:trackUUID];
+        
+        __weak RTCCameraVideoCapturer* capturer = self.videoCapturer;
+        self.videoCapturerStopHandlers[videoTrack.trackId] = ^(CompletionHandler handler) {
+            NSLog(@"Stop video capturer, trackID %@", videoTrack.trackId);
+            [capturer stopCaptureWithCompletionHandler:handler];
+        };
+        
         [mediaStream addVideoTrack:videoTrack];
 
         successCallback(mediaStream);

--- a/common/darwin/Classes/FlutterWebRTCPlugin.h
+++ b/common/darwin/Classes/FlutterWebRTCPlugin.h
@@ -21,7 +21,7 @@ typedef void (^CapturerStopHandler)(CompletionHandler handler);
 @property (nonatomic, strong) NSMutableDictionary<NSString *, RTCMediaStream *> *localStreams;
 @property (nonatomic, strong) NSMutableDictionary<NSString *, RTCMediaStreamTrack *> *localTracks;
 @property (nonatomic, strong) NSMutableDictionary<NSNumber *, FlutterRTCVideoRenderer *> *renders;
-@property (nonatomic, strong) NSMutableDictionary<RTCVideoSource *, CapturerStopHandler> *videoCapturerStopHandlers;
+@property (nonatomic, strong) NSMutableDictionary<NSString *, CapturerStopHandler> *videoCapturerStopHandlers;
 
 #if TARGET_OS_IPHONE
 @property (nonatomic, retain) UIViewController *viewController;/*for broadcast or ReplayKit */

--- a/common/darwin/Classes/FlutterWebRTCPlugin.m
+++ b/common/darwin/Classes/FlutterWebRTCPlugin.m
@@ -362,15 +362,14 @@
             for (RTCVideoTrack *track in stream.videoTracks) {
                 [self.localTracks removeObjectForKey:track.trackId];
                 RTCVideoTrack *videoTrack = (RTCVideoTrack *)track;
-                RTCVideoSource *source = videoTrack.source;
-                CapturerStopHandler stopHandler = self.videoCapturerStopHandlers[streamId];
+                CapturerStopHandler stopHandler = self.videoCapturerStopHandlers[videoTrack.trackId];
                 if(stopHandler) {
                     shouldCallResult = NO;
                     stopHandler(^{
-                          NSLog(@"video capturer stopped, id = %@", streamId);
+                          NSLog(@"video capturer stopped, trackID = %@", videoTrack.trackId);
                           result(nil);
                         });
-                    [self.videoCapturerStopHandlers removeObjectForKey:source];
+                    [self.videoCapturerStopHandlers removeObjectForKey:videoTrack.trackId];
                 }
             }
             for (RTCAudioTrack *track in stream.audioTracks) {
@@ -465,8 +464,8 @@
             [peerConnection.remoteTracks removeAllObjects];
 
             // Clean up peerConnection's dataChannels.
-            NSMutableDictionary<NSNumber *, RTCDataChannel *> *dataChannels = peerConnection.dataChannels;
-            for (NSNumber *dataChannelId in dataChannels) {
+            NSMutableDictionary<NSString *, RTCDataChannel *> *dataChannels = peerConnection.dataChannels;
+            for (NSString *dataChannelId in dataChannels) {
                 dataChannels[dataChannelId].delegate = nil;
                 // There is no need to close the RTCDataChannel because it is owned by the
                 // RTCPeerConnection and the latter will close the former.
@@ -1649,10 +1648,8 @@
             return @"recvonly";
         case RTCRtpTransceiverDirectionInactive:
             return @"inactive";
-#if TARGET_OS_IPHONE
         case RTCRtpTransceiverDirectionStopped:
             return @"stopped";
-#endif
                break;
        }
     return nil;


### PR DESCRIPTION
Fix compilation warnings under iOS/macOS
```
2022-07-18 11:01:26.250 xcodebuild[8395:113863] Requested but did not find extension point with identifier Xcode.IDEKit.ExtensionSentinelHostApplications for extension Xcode.DebuggerFoundation.AppExtensionHosts.watchOS of plug-in com.apple.dt.IDEWatchSupportCore
2022-07-18 11:01:26.251 xcodebuild[8395:113863] Requested but did not find extension point with identifier Xcode.IDEKit.ExtensionPointIdentifierToBundleIdentifier for extension Xcode.DebuggerFoundation.AppExtensionToBundleIdentifierMap.watchOS of plug-in com.apple.dt.IDEWatchSupportCore
--- xcodebuild: WARNING: Using the first of multiple matching destinations:
{ platform:macOS, arch:x86_64, id:9B436656-E6E8-5C29-BA5E-C573E7003F09 }
{ platform:macOS, name:Any Mac }                                        
/Users/duanweiwei/.pub-cache/hosted/pub.dartlang.org/flutter_webrtc-0.8.12/macos/Classes/FlutterWebRTCPlugin.m:345:31: warning: incompatible pointer types sending 'NSString *' to parameter of type 'NSNumber * _Nonnull' [-Wincompatible-pointer-types]
                dataChannelId:dataChannelId                             
                              ^~~~~~~~~~~~~                             
In file included from /Users/duanweiwei/.pub-cache/hosted/pub.dartlang.org/flutter_webrtc-0.8.12/macos/Classes/FlutterWebRTCPlugin.m:4:
/Users/duanweiwei/.pub-cache/hosted/pub.dartlang.org/flutter_webrtc-0.8.12/macos/Classes/FlutterRTCDataChannel.h:25:44: note: passing argument to parameter 'dataChannelId' here
         dataChannelId:(nonnull NSNumber *)dataChannelId                
                                           ^                            
/Users/duanweiwei/.pub-cache/hosted/pub.dartlang.org/flutter_webrtc-0.8.12/macos/Classes/FlutterWebRTCPlugin.m:366:82: warning: incompatible pointer types sending 'NSString *' to parameter of type 'RTCVideoSource * _Nonnull' [-Wincompatible-pointer-types]
                CapturerStopHandler stopHandler = self.videoCapturerStopHandlers[streamId];
                                                                                 ^~~~~~~~
In module 'Foundation' imported from /Users/duanweiwei/.pub-cache/hosted/pub.dartlang.org/flutter_webrtc-0.8.12/macos/Classes/FlutterWebRTCPlugin.h:7:
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk/System/Library/Frameworks/Foundation.framework/Headers/NSDictionary.h:46:57: note: passing argument to parameter 'key' here
- (nullable ObjectType)objectForKeyedSubscript:(KeyType)key API_AVAILABLE(macos(10.8), ios(6.0), watchos(2.0), tvos(9.0));
                                                        ^               
/Users/duanweiwei/.pub-cache/hosted/pub.dartlang.org/flutter_webrtc-0.8.12/macos/Classes/FlutterWebRTCPlugin.m:468:64: warning: incompatible pointer types initializing 'NSMutableDictionary<NSNumber *,RTCDataChannel *> *' with an expression of type 'NSMutableDictionary<NSString *,RTCDataChannel *> *' [-Wincompatible-pointer-types]
            NSMutableDictionary<NSNumber *, RTCDataChannel *> *dataChannels = peerConnection.dataChannels;
                                                               ^              ~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/duanweiwei/.pub-cache/hosted/pub.dartlang.org/flutter_webrtc-0.8.12/macos/Classes/FlutterWebRTCPlugin.m:1643:16: warning: enumeration value 'RTCRtpTransceiverDirectionStopped' not handled in switch [-Wswitch]
       switch (direction) {                                             
               ^                                                        
/Users/duanweiwei/.pub-cache/hosted/pub.dartlang.org/flutter_webrtc-0.8.12/macos/Classes/FlutterWebRTCPlugin.m:1643:16: note: add missing switch cases
       switch (direction) {                                             
               ^                                                        
4 warnings generated.    
```