### PR TITLE
fix : iOS app could not change camera resolutions 

### DIFF
--- a/common/darwin/Classes/FlutterRTCMediaStream.m
+++ b/common/darwin/Classes/FlutterRTCMediaStream.m
@@ -303,21 +303,21 @@ typedef void (^NavigatorUserMediaSuccessCallback)(RTCMediaStream *mediaStream);
     if(mandatory && [mandatory isKindOfClass:[NSDictionary class]])
     {
         id widthConstraint = mandatory[@"minWidth"];
-        if ([widthConstraint isKindOfClass:[NSString class]]) {
+        if ([widthConstraint isKindOfClass:[NSString class]] || widthConstraint isKindOfClass:[NSNumber class]]) {
             int possibleWidth = [widthConstraint intValue];
             if (possibleWidth != 0) {
                 self._targetWidth = possibleWidth;
             }
         }
         id heightConstraint = mandatory[@"minHeight"];
-        if ([heightConstraint isKindOfClass:[NSString class]]) {
+        if ([heightConstraint isKindOfClass:[NSString class]] || [heightConstraint isKindOfClass:[NSNumber class]]) {
             int possibleHeight = [heightConstraint intValue];
             if (possibleHeight != 0) {
                 self._targetHeight = possibleHeight;
             }
         }
         id fpsConstraint = mandatory[@"minFrameRate"];
-        if ([fpsConstraint isKindOfClass:[NSString class]]) {
+        if ([fpsConstraint isKindOfClass:[NSString class]] || [fpsConstraint isKindOfClass:[NSNumber class]]) {
             int possibleFps = [fpsConstraint intValue];
             if (possibleFps != 0) {
                 self._targetFps = possibleFps;


### PR DESCRIPTION
# Changes 
- [x] Allow set the media constraints: video resolutions, framerate with number data type

# Why 
I was facing issues with iOS. I can not change the camera resolutions in the iOS version.
Didn't see these issues with Android.

It was caused by a mismatched data type in the media constraints (Dart <-> Object C)

### In iOS 
- if we set the media constraints like that, **it will not work.**
```
final Map<String, dynamic> mediaConstraints = {
      'audio': true,
      'video': {
        'width: 640, 
        'height': 480,
        'frameRate': 24,
        'facingMode': 'user',
        'optional': [],
      }
};
```

- if we set the media constraints like that, **it will work.**
```
final Map<String, dynamic> mediaConstraints = {
      'audio': true,
      'video': {
        'width: '640', 
        'height': '480',
        'frameRate': '24',
        'facingMode': 'user',
        'optional': [],
      }
};
```

 - Because width, height, and framerate are converted to NSString on Object C.
 - The logic is set from [HERE](https://github.com/flutter-webrtc/flutter-webrtc/blob/main/common/darwin/Classes/FlutterRTCMediaStream.m#L306) 
 ```
        id widthConstraint = mandatory[@"minWidth"];
       if ([widthConstraint isKindOfClass:[NSString class]]) {
           int possibleWidth = [widthConstraint intValue];
           if (possibleWidth != 0) {
               self._targetWidth = possibleWidth;
           }
       }
       id heightConstraint = mandatory[@"minHeight"];
       if ([heightConstraint isKindOfClass:[NSString class]]) {
           int possibleHeight = [heightConstraint intValue];
           if (possibleHeight != 0) {
               self._targetHeight = possibleHeight;
           }
       }
       id fpsConstraint = mandatory[@"minFrameRate"];
       if ([fpsConstraint isKindOfClass:[NSString class]]) {
           int possibleFps = [fpsConstraint intValue];
           if (possibleFps != 0) {
               self._targetFps = possibleFps;
           }
       }
 ```

**- But the data for video resolutions and framerate could be NSString or NSNumber.**

- Actually, we could use `respondsToSelector:` to check if the object responds to `int value` method. But I think it is not clear enough for everyone 
 



