### PR TITLE
hotfix : iOS : Missing '[' at start of message send expression

### DIFF
--- a/common/darwin/Classes/FlutterRTCMediaStream.m
+++ b/common/darwin/Classes/FlutterRTCMediaStream.m
@@ -303,7 +303,7 @@ typedef void (^NavigatorUserMediaSuccessCallback)(RTCMediaStream *mediaStream);
     if(mandatory && [mandatory isKindOfClass:[NSDictionary class]])
     {
         id widthConstraint = mandatory[@"minWidth"];
-        if ([widthConstraint isKindOfClass:[NSString class]] || widthConstraint isKindOfClass:[NSNumber class]]) {
+        if ([widthConstraint isKindOfClass:[NSString class]] || [widthConstraint isKindOfClass:[NSNumber class]]) {
             int possibleWidth = [widthConstraint intValue];
             if (possibleWidth != 0) {
                 self._targetWidth = possibleWidth;


### PR DESCRIPTION
It's related to my recent PR https://github.com/flutter-webrtc/flutter-webrtc/pull/1033
The source code could not compile after the PR https://github.com/flutter-webrtc/flutter-webrtc/pull/1033

<img width="1556" alt="Screen Shot 2022-07-31 at 16 21 13" src="https://user-images.githubusercontent.com/2597710/182020039-35d9865e-b617-4651-b46b-5d7809223fc6.png">

[ERROR HERE](https://github.com/flutter-webrtc/flutter-webrtc/blob/main/common/darwin/Classes/FlutterRTCMediaStream.m#L306)

This PR will fix this syntax error so it will not break the codebase anymore. 
`flutter-webrtc` seems to need to be integrated CI pipeline to check the PR before merging it  
@cloudwebrtc 