### PR TITLE
Added callback onFirstFrameRendered

### DIFF
--- a/lib/src/native/rtc_video_renderer_impl.dart
+++ b/lib/src/native/rtc_video_renderer_impl.dart
@@ -83,6 +83,7 @@ class RTCVideoRenderer extends ValueNotifier<RTCVideoValue>
         break;
       case 'didFirstFrameRendered':
         value = value.copyWith(renderVideo: renderVideo);
+        onFirstFrameRendered?.call();
         break;
     }
   }

--- a/lib/src/native/rtc_video_renderer_impl.dart
+++ b/lib/src/native/rtc_video_renderer_impl.dart
@@ -40,6 +40,9 @@ class RTCVideoRenderer extends ValueNotifier<RTCVideoValue>
   Function? onResize;
 
   @override
+  Function? onFirstFrameRendered;
+
+  @override
   set srcObject(MediaStream? stream) {
     if (textureId == null) throw 'Call initialize before setting the stream';
 


### PR DESCRIPTION
This PR will provide a callback to notify user that the first frame is rendered.
User can use it to know when first frame of a stream is started playing.