### PR TITLE
override `onFirstFrameRendered`

### DIFF
--- a/lib/src/native/rtc_video_renderer_impl.dart
+++ b/lib/src/native/rtc_video_renderer_impl.dart
@@ -120,4 +120,7 @@ class RTCVideoRenderer extends ValueNotifier<RTCVideoValue>
     // TODO(cloudwebrtc): related to https://github.com/flutter-webrtc/flutter-webrtc/issues/395
     throw UnimplementedError('This is not implement yet');
   }
+
+  @override
+  Function? onFirstFrameRendered;
 }

--- a/lib/src/web/rtc_video_renderer_impl.dart
+++ b/lib/src/web/rtc_video_renderer_impl.dart
@@ -257,4 +257,7 @@ class RTCVideoRenderer extends ValueNotifier<RTCVideoValue>
 
   @override
   Function? onResize;
+
+  @override
+  Function? onFirstFrameRendered;
 }


### PR DESCRIPTION
Fix `Error: The non-abstract class 'RTCVideoRenderer' is missing implementations` error #899