### PR TITLE
Fix/rtp transceiver direction type 4

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -49,7 +49,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.github.webrtc-sdk:android:104.5112.01'
+    implementation "com.github.danysmall:android:105.0.0"
     implementation "com.twilio:audioswitch:1.1.5"
     implementation 'androidx.annotation:annotation:1.1.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"

--- a/android/src/main/java/org/webrtc/SimulcastVideoEncoder.java
+++ b/android/src/main/java/org/webrtc/SimulcastVideoEncoder.java
@@ -1,0 +1,28 @@
+package org.webrtc;
+
+public class SimulcastVideoEncoder extends WrappedNativeVideoEncoder {
+
+    static native long nativeCreateEncoder(VideoEncoderFactory primary, VideoEncoderFactory fallback, VideoCodecInfo info);
+
+    VideoEncoderFactory primary;
+    VideoEncoderFactory fallback;
+    VideoCodecInfo info;
+
+    public SimulcastVideoEncoder(VideoEncoderFactory primary, VideoEncoderFactory fallback, VideoCodecInfo info) {
+        this.primary = primary;
+        this.fallback = fallback;
+        this.info = info;
+    }
+
+    @Override
+    public long createNativeVideoEncoder() {
+        return nativeCreateEncoder(primary, fallback, info);
+    }
+
+    @Override
+    public boolean isHardwareEncoder() {
+        return false;
+    }
+
+}
+

--- a/android/src/main/java/org/webrtc/SimulcastVideoEncoderFactory.java
+++ b/android/src/main/java/org/webrtc/SimulcastVideoEncoderFactory.java
@@ -1,0 +1,43 @@
+/*
+ *  Copyright 2017 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+
+package org.webrtc;
+
+import androidx.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Arrays;
+
+public class SimulcastVideoEncoderFactory implements VideoEncoderFactory {
+
+    VideoEncoderFactory primary;
+    VideoEncoderFactory fallback;
+
+    public SimulcastVideoEncoderFactory(VideoEncoderFactory primary, VideoEncoderFactory fallback) {
+        this.primary = primary;
+        this.fallback = fallback;
+    }
+
+    @Nullable
+    @Override
+    public VideoEncoder createEncoder(VideoCodecInfo info) {
+        return new SimulcastVideoEncoder(primary, fallback, info);
+    }
+
+    @Override
+    public VideoCodecInfo[] getSupportedCodecs() {
+        List<VideoCodecInfo> codecs = new ArrayList<VideoCodecInfo>();
+        codecs.addAll(Arrays.asList(primary.getSupportedCodecs()));
+        codecs.addAll(Arrays.asList(fallback.getSupportedCodecs()));
+        return codecs.toArray(new VideoCodecInfo[codecs.size()]);
+    }
+
+}


### PR DESCRIPTION
Correspond to [https://w3c.github.io/webrtc-pc/#dom-rtcrtptransceiverdirection](https://w3c.github.io/webrtc-pc/#dom-rtcrtptransceiverdirection)
---
Changed dependency to latest unofficial build on webrtc android library that contains five values of RtpTransceiverDirection enum. 
Should be temporary solution waiting for the build to fix exceptoin `RtpTransceiverDirection type 4: unknown native type`