### PR TITLE
Have same remote streams id then found wrong MediaStream.

### DIFF
--- a/common/cpp/include/flutter_video_renderer.h
+++ b/common/cpp/include/flutter_video_renderer.h
@@ -60,7 +60,8 @@ class FlutterVideoRendererManager {
       std::unique_ptr<MethodResult<EncodableValue>> result);
 
   void SetMediaStream(int64_t texture_id,
-                      const std::string& stream_id);
+                      const std::string& stream_id,
+                      const std::string& peerConnectionId);
 
   void VideoRendererDispose(
       int64_t texture_id,

--- a/common/cpp/include/flutter_webrtc_base.h
+++ b/common/cpp/include/flutter_webrtc_base.h
@@ -148,7 +148,7 @@ class FlutterWebRTCBase {
   void RemovePeerConnectionObserversForId(const std::string& id);
 
   scoped_refptr<RTCMediaStream> MediaStreamForId(const std::string& id,
-                                                 std::string peerConnectionId = "");
+                                                 std::string peerConnectionId = std::string());
 
   void RemoveStreamForId(const std::string& id);
 

--- a/common/cpp/include/flutter_webrtc_base.h
+++ b/common/cpp/include/flutter_webrtc_base.h
@@ -147,7 +147,8 @@ class FlutterWebRTCBase {
 
   void RemovePeerConnectionObserversForId(const std::string& id);
 
-  scoped_refptr<RTCMediaStream> MediaStreamForId(const std::string& id);
+  scoped_refptr<RTCMediaStream> MediaStreamForId(const std::string& id,
+                                                 std::string peerConnectionId = "");
 
   void RemoveStreamForId(const std::string& id);
 

--- a/common/cpp/src/flutter_video_renderer.cc
+++ b/common/cpp/src/flutter_video_renderer.cc
@@ -143,7 +143,8 @@ void FlutterVideoRendererManager::CreateVideoRendererTexture(
 }
 
 void FlutterVideoRendererManager::SetMediaStream(int64_t texture_id,
-                                                 const std::string& stream_id) {
+                                                 const std::string& stream_id,
+                                                 const std::string& peerConnectionId) {
   scoped_refptr<RTCMediaStream> stream =
       base_->MediaStreamForId(stream_id);
   auto it = renderers_.find(texture_id);

--- a/common/cpp/src/flutter_video_renderer.cc
+++ b/common/cpp/src/flutter_video_renderer.cc
@@ -146,7 +146,7 @@ void FlutterVideoRendererManager::SetMediaStream(int64_t texture_id,
                                                  const std::string& stream_id,
                                                  const std::string& peerConnectionId) {
   scoped_refptr<RTCMediaStream> stream =
-      base_->MediaStreamForId(stream_id);
+      base_->MediaStreamForId(stream_id, peerConnectionId);
   auto it = renderers_.find(texture_id);
   if (it != renderers_.end()) {
     FlutterVideoRenderer *renderer = it->second.get();

--- a/common/cpp/src/flutter_webrtc.cc
+++ b/common/cpp/src/flutter_webrtc.cc
@@ -454,8 +454,9 @@ void FlutterWebRTC::HandleMethodCall(
         GetValue<EncodableMap>(*method_call.arguments());
     const std::string stream_id = findString(params, "streamId");
     int64_t texture_id = findLongInt(params, "textureId");
+    const std::string peerConnectionId = findString(params, "ownerTag");
 
-    SetMediaStream(texture_id, stream_id);
+    SetMediaStream(texture_id, stream_id, peerConnectionId);
     result->Success();
   } else if (method_call.method_name().compare(
                  "mediaStreamTrackSwitchCamera") == 0) {

--- a/common/cpp/src/flutter_webrtc_base.cc
+++ b/common/cpp/src/flutter_webrtc_base.cc
@@ -100,10 +100,21 @@ void FlutterWebRTCBase::RemovePeerConnectionObserversForId(
 }
 
 scoped_refptr<RTCMediaStream> FlutterWebRTCBase::MediaStreamForId(
-    const std::string& id) {
+    const std::string& id,
+    std::string peerConnectionId/* = ""*/) {
   auto it = local_streams_.find(id);
   if (it != local_streams_.end()) {
     return (*it).second;
+  }
+
+  if (!peerConnectionId.empty()) {
+    auto pco = peerconnection_observers_.find(peerConnectionId);
+    if (peerconnection_observers_.end() != pco) {
+      auto stream = pco->second->MediaStreamForId(id);
+      if (stream != nullptr) {
+        return stream;
+      }
+    }
   }
 
   for (auto kv : peerconnection_observers_) {

--- a/common/cpp/src/flutter_webrtc_base.cc
+++ b/common/cpp/src/flutter_webrtc_base.cc
@@ -101,7 +101,7 @@ void FlutterWebRTCBase::RemovePeerConnectionObserversForId(
 
 scoped_refptr<RTCMediaStream> FlutterWebRTCBase::MediaStreamForId(
     const std::string& id,
-    std::string peerConnectionId/* = ""*/) {
+    std::string peerConnectionId/* = std::string()*/) {
   auto it = local_streams_.find(id);
   if (it != local_streams_.end()) {
     return (*it).second;


### PR DESCRIPTION
In multiple peerconnection find stream id by for loop. But stream id for each peerconnection may be the same.