### PR TITLE
fix compile for linux

### DIFF
--- a/common/cpp/src/flutter_peerconnection.cc
+++ b/common/cpp/src/flutter_peerconnection.cc
@@ -810,12 +810,12 @@ void FlutterPeerConnection::GetStats(
         pc->GetStats(
             receiver,
             [result_ptr](const vector<scoped_refptr<MediaRTCStats>> reports) {
-              EncodableList list;
+              std::vector<EncodableValue> list;
               for (int i = 0; i < reports.size(); i++) {
-                list.push_back(statsToMap(reports[i]));
+                list.push_back(EncodableValue(statsToMap(reports[i])));
               }
               EncodableMap params;
-              params[EncodableValue("stats")] = list;
+              params[EncodableValue("stats")] = EncodableValue(list);
               result_ptr->Success(EncodableValue(params));
             },
             [result_ptr](const char* error) {
@@ -828,16 +828,15 @@ void FlutterPeerConnection::GetStats(
     for (auto sender : senders.std_vector()) {
       if (sender->track()->id().c_string() == track_id) {
         found = true;
-        EncodableList list;
         pc->GetStats(
             sender,
             [result_ptr](const vector<scoped_refptr<MediaRTCStats>> reports) {
-              EncodableList list;
+              std::vector<EncodableValue> list;
               for (int i = 0; i < reports.size(); i++) {
-                list.push_back(statsToMap(reports[i]));
+                list.push_back(EncodablveValue(statsToMap(reports[i])));
               }
               EncodableMap params;
-              params[EncodableValue("stats")] = list;
+              params[EncodableValue("stats")] = EncodableValue(list);
               result_ptr->Success(EncodableValue(params));
             },
             [result_ptr](const char* error) {
@@ -852,12 +851,12 @@ void FlutterPeerConnection::GetStats(
   } else {
     pc->GetStats(
         [result_ptr](const vector<scoped_refptr<MediaRTCStats>> reports) {
-        EncodableList list;
+        std::vector<EncodableValue> list;
         for (int i = 0; i < reports.size(); i++) {
-          list.push_back(statsToMap(reports[i]));
+          list.push_back(EncodableValue(statsToMap(reports[i])));
         }
         EncodableMap params;
-        params[EncodableValue("stats")] = list;
+        params[EncodableValue("stats")] = EncodableValue(list);
         result_ptr->Success(EncodableValue(params));
       },
         [result_ptr](const char* error) {

--- a/common/cpp/src/flutter_screen_capture.cc
+++ b/common/cpp/src/flutter_screen_capture.cc
@@ -63,7 +63,7 @@ void FlutterScreenCapture::GetDesktopSources(
 
   std::cout << " sources: " << sources.size() << std::endl;
   result->Success(
-      EncodableValue(EncodableMap{{EncodableValue("sources"), sources}}));
+      EncodableValue(EncodableMap{{EncodableValue("sources"), EncodableValue(sources)}}));
 }
 
 void FlutterScreenCapture::UpdateDesktopSources(
@@ -74,7 +74,7 @@ void FlutterScreenCapture::UpdateDesktopSources(
     return;
   }
   result->Success(
-      EncodableValue(EncodableMap{{EncodableValue("result"), true}}));
+      EncodableValue(EncodableMap{{EncodableValue("result"), EncodableValue(true)}}));
 }
 
 void FlutterScreenCapture::OnMediaSourceAdded(


### PR DESCRIPTION
For some reason, clang fails to recognize that EncodableList and EncodableMap as acceptable variant types for EncodableValue 