### PR TITLE
Fix #883

### DIFF
--- a/lib/src/media_recorder.dart
+++ b/lib/src/media_recorder.dart
@@ -18,8 +18,12 @@ class MediaRecorder extends rtc.MediaRecorder {
   void startWeb(
     MediaStream stream, {
     Function(dynamic blob, bool isLastOne)? onDataChunk,
-    String? mimeType,
+    String? mimeType,int timeSlice = 1000,
   }) =>
-      _delegate.startWeb(stream,
-          onDataChunk: onDataChunk, mimeType: mimeType ?? 'video/webm');
+      _delegate.startWeb(
+        stream,
+        onDataChunk: onDataChunk,
+        mimeType: mimeType ?? 'video/webm',
+        timeSlice: timeSlice,
+      );
 }


### PR DESCRIPTION
Changes - Now there is a timeslice argument in startWeb Function of MediaRecorder, which also resolves the problem of onDataChunk Method not triggering unless we stop the recording.