### PR TITLE
Fix groupId #1145 for IOS 

### DIFF
--- a/common/darwin/Classes/FlutterRTCMediaStream.m
+++ b/common/darwin/Classes/FlutterRTCMediaStream.m
@@ -513,6 +513,7 @@ typedef void (^NavigatorUserMediaSuccessCallback)(RTCMediaStream *mediaStream);
                              @"facing": @"",
                              @"deviceId": port.UID,
                              @"label": port.portName,
+                             @"groupId": port.portType,
                              @"kind": @"audioinput",
                              }];
     }
@@ -523,6 +524,7 @@ typedef void (^NavigatorUserMediaSuccessCallback)(RTCMediaStream *mediaStream);
                                  @"facing": @"",
                                  @"deviceId": @"Speaker",
                                  @"label": @"Speaker",
+                                 @"groupId": @"Speaker",
                                  @"kind": @"audiooutput",
                                  }];
         }
@@ -530,6 +532,7 @@ typedef void (^NavigatorUserMediaSuccessCallback)(RTCMediaStream *mediaStream);
                              @"facing": @"",
                              @"deviceId": port.UID,
                              @"label": port.portName,
+                             @"groupId": port.portType,
                              @"kind": @"audiooutput",
                              }];
     }


### PR DESCRIPTION
For IOS, the navigator.mediaDevices.enumerateDevices() method returns an empty one to groupId. This fixed the problem. 