### PR TITLE
fix: :bug: Fixed the problem that iOS earphones and speakers do not switch

### DIFF
--- a/common/darwin/Classes/AudioUtils.m
+++ b/common/darwin/Classes/AudioUtils.m
@@ -67,19 +67,28 @@
     [session lockForConfiguration];
     NSError *error = nil;
     if(!enable) {
-        [session setCategory:config.category
-                 withOptions:config.categoryOptions
-                       error:&error];
         [session setMode:config.mode error:&error];
-        BOOL success = [session setActive:YES error:&error];
+        BOOL success = [session setCategory:config.category
+                                withOptions:AVAudioSessionCategoryOptionAllowAirPlay|AVAudioSessionCategoryOptionAllowBluetoothA2DP|AVAudioSessionCategoryOptionAllowBluetooth
+                                      error:&error];
+
+        success = [session.session overrideOutputAudioPort:kAudioSessionOverrideAudioRoute_None error:&error];
+        if (!success)  NSLog(@"Port override failed due to: %@", error);
+
+        success = [session setActive:YES error:&error];
         if (!success) NSLog(@"Audio session override failed: %@", error);
         else NSLog(@"AudioSession override via Earpiece/Headset is successful ");
+
+        
     } else {
-        BOOL success = [session setCategory:config.category
-                                withOptions:AVAudioSessionCategoryOptionDefaultToSpeaker
-                                      error:&error];
         [session setMode:config.mode error:&error];
+        BOOL success = [session setCategory:config.category
+                                withOptions:AVAudioSessionCategoryOptionDefaultToSpeaker|AVAudioSessionCategoryOptionAllowAirPlay|AVAudioSessionCategoryOptionAllowBluetoothA2DP|AVAudioSessionCategoryOptionAllowBluetooth
+                                      error:&error];
+        
+        success = [session overrideOutputAudioPort:kAudioSessionOverrideAudioRoute_Speaker error:&error];
         if (!success)  NSLog(@"Port override failed due to: %@", error);
+
         success = [session setActive:YES error:&error];
         if (!success) NSLog(@"Audio session override failed: %@", error);
         else NSLog(@"AudioSession override via Loudspeaker is successful ");


### PR DESCRIPTION
First of all, sorry for my terrible English

**[Environment]**
iOS 16+
flutter-webrtc: 0.9.11

**[Device]**
iphone xs, iphone12

**[Issue]**
After calling setSpeakerphoneOn, when switching Bluetooth earphones and speakers, the sound session is not changed and the result of calling the method is maintained.

**[Reproduction procedure]**
- successful webrtc connection.
- Check earphone connection status through AVAudioSession outputs.
- Call setSpearkerphoneOn according to the connection status.
- Bluetooth earphone connection.
- AVAudioSessionRouteChangeNotification observer not working.
- Only the speaker is output.

**[Resolution]**
- Add overrideOutputAudioPort method.
- Change withOptions to enable continuous sound session route change detection.
- Moved setMode forward because of the playAndRecord option.

**[REF]**
https://developer.apple.com/documentation/avfaudio/avaudiosession/2887480-setcategory
https://developer.apple.com/documentation/avfaudio/avaudiosession/1616443-overrideoutputaudioport
https://developer.apple.com/documentation/avfaudio/avaudiosession
https://developer.apple.com/library/archive/documentation/Audio/Conceptual/AudioSessionProgrammingGuide/HandlingAudioHardwareRouteChanges/HandlingAudioHardwareRouteChanges.html#//apple_ref/doc/uid/TP40007875-CH5-SW1
https://webrtc.googlesource.com/src//+/1845922d5a1bf9c27deeffb4a8c8daea124434c1/sdk/objc/components/audio/RTCAudioSessionConfiguration.m

If you have any problems, please leave a comment.
thank you.