### PR TITLE
fix : iOS crash when `sdpMLineIndex` is null on `addCandidate`

### DIFF
--- a/common/darwin/Classes/FlutterWebRTCPlugin.m
+++ b/common/darwin/Classes/FlutterWebRTCPlugin.m
@@ -344,7 +344,11 @@
         NSString* peerConnectionId = argsMap[@"peerConnectionId"];
         NSDictionary* candMap = argsMap[@"candidate"];
         NSString *sdp = candMap[@"candidate"];
-        int sdpMLineIndex = ((NSNumber*)candMap[@"sdpMLineIndex"]).intValue;
+        id sdpMLineIndexValue = candMap[@"sdpMLineIndex"];
+        int sdpMLineIndex = 0;
+        if (![sdpMLineIndexValue isKindOfClass:[NSNull class]]) {
+            sdpMLineIndex = ((NSNumber*)candMap[@"sdpMLineIndex"]).intValue;
+        }
         NSString *sdpMid = candMap[@"sdpMid"];
 
         RTCIceCandidate* candidate = [[RTCIceCandidate alloc] initWithSdp:sdp sdpMLineIndex:sdpMLineIndex sdpMid:sdpMid];


### PR DESCRIPTION
# Changes 
- [x] Fix crash in `FlutterWebRTCPlugin.m`.  The `sdpMLineIndex` value could be "null" on `addCandidate` event.

# Why 
- I was facing issues with iOS. 
- One of the device in the meeting room is a viewer only, it is not has a camera or microphone. It means the candidate has no media source yet. This device joined the meeting and makes all iOS devices crash and out from the meeting. The android devices are not affected. 

> refs:  https://developer.mozilla.org/en-US/docs/Web/API/RTCIceCandidate/sdpMLineIndex
> from the document specification ... `sdpMLineIndex` could be `null`.

- But in the iOS code, we are expected `sdpMLineIndex` will be NSString or NSNumber. So that we could call intValue() method to get the value. But actually, in that case, `sdpMLineIndex` is an `NSNull`. And the code crash.

 # Screenshot 

<img width="963" alt="Screen Shot 2022-11-03 at 21 56 48" src="https://user-images.githubusercontent.com/2597710/199755600-606801d0-bd50-4db1-a934-585ab1e74dd3.png">

```
Fatal Exception: NSInvalidArgumentException
-[NSNull intValue]: unrecognized selector sent to instance 0x1dbca4558
Fatal Exception: NSInvalidArgumentException
0  CoreFoundation                 0x9904c __exceptionPreprocess
1  libobjc.A.dylib                0x15f54 objc_exception_throw
2  CoreFoundation                 0x176014 +[NSObject(NSObject) _copyDescription]
3  CoreFoundation                 0x2e474 ___forwarding___
4  CoreFoundation                 0x2d5b0 _CF_forwarding_prep_0
5  App                          0x15610bc -[FlutterWebRTCPlugin handleMethodCall:result:] + 331 (FlutterWebRTCPlugin.m:331)
```


