### PR TITLE
fix(ios): custom audio session configuration is overwritten

### DIFF
--- a/common/darwin/Classes/AudioUtils.m
+++ b/common/darwin/Classes/AudioUtils.m
@@ -23,7 +23,7 @@
                        error:nil];
         [session setMode:config.mode error:nil];
         [session unlockForConfiguration];
-    } else if (!recording || (session.category == AVAudioSessionCategoryAmbient
+    } else if (!recording && (session.category == AVAudioSessionCategoryAmbient
                               || session.category == AVAudioSessionCategorySoloAmbient)) {
         config.category = AVAudioSessionCategoryPlayback;
         config.categoryOptions = 0;

--- a/common/darwin/Classes/AudioUtils.m
+++ b/common/darwin/Classes/AudioUtils.m
@@ -67,26 +67,14 @@
     [session lockForConfiguration];
     NSError *error = nil;
     if(!enable) {
-        [session setMode:config.mode error:&error];
-        BOOL success = [session setCategory:config.category
-                                withOptions:AVAudioSessionCategoryOptionAllowAirPlay|AVAudioSessionCategoryOptionAllowBluetoothA2DP|AVAudioSessionCategoryOptionAllowBluetooth
-                                      error:&error];
-
-        success = [session.session overrideOutputAudioPort:kAudioSessionOverrideAudioRoute_None error:&error];
+        BOOL success = [session.session overrideOutputAudioPort:kAudioSessionOverrideAudioRoute_None error:&error];
         if (!success)  NSLog(@"Port override failed due to: %@", error);
 
         success = [session setActive:YES error:&error];
         if (!success) NSLog(@"Audio session override failed: %@", error);
         else NSLog(@"AudioSession override via Earpiece/Headset is successful ");
-
-        
     } else {
-        [session setMode:config.mode error:&error];
-        BOOL success = [session setCategory:config.category
-                                withOptions:AVAudioSessionCategoryOptionDefaultToSpeaker|AVAudioSessionCategoryOptionAllowAirPlay|AVAudioSessionCategoryOptionAllowBluetoothA2DP|AVAudioSessionCategoryOptionAllowBluetooth
-                                      error:&error];
-        
-        success = [session overrideOutputAudioPort:kAudioSessionOverrideAudioRoute_Speaker error:&error];
+        BOOL success = [session overrideOutputAudioPort:kAudioSessionOverrideAudioRoute_Speaker error:&error];
         if (!success)  NSLog(@"Port override failed due to: %@", error);
 
         success = [session setActive:YES error:&error];


### PR DESCRIPTION
Before starting a call, we use the [`audio_session`](https://pub.dev/packages/audio_session) plugin to configure the audio settings for the call (code sample below). This allows us to set the [`defaultToSpeaker`](https://developer.apple.com/documentation/avfaudio/avaudiosession/categoryoptions/1616462-defaulttospeaker) option so that:

> audio is always routed to the speaker rather than the receiver *if no other accessories, such as headphones, are in use*.

This is different than the current implementation of [`setSpeakerphoneOn`](https://github.com/flutter-webrtc/flutter-webrtc/blob/39021f7d71afcd5827d44fd00a0abc6b04940cf4/common/darwin/Classes/AudioUtils.m#L64), which uses [`overrideOutputAudioPort`](https://developer.apple.com/documentation/avfaudio/avaudiosession/1616443-overrideoutputaudioport) to:

> route audio to the built-in speaker and microphone *regardless of other settings*.

The problem is that our audio settings get overwritten by `setSpeakerphoneOn`, which, as of https://github.com/flutter-webrtc/flutter-webrtc/pull/1122, gets called even though we never directly call `Helper.setSpeakerphoneOn`.

This PR changes  `setSpeakerphoneOn` so that it no longer attempts to change the audio session mode or category; rather, it relies on them being configured by [`ensureAudioSessionWithRecording`](https://github.com/flutter-webrtc/flutter-webrtc/blob/39021f7d71afcd5827d44fd00a0abc6b04940cf4/common/darwin/Classes/AudioUtils.m#L7) or by the app (`ensureAudioSessionWithRecording` correctly avoids overwriting the settings if the category is already [`AVAudioSessionCategoryPlayAndRecord`](https://developer.apple.com/documentation/avfaudio/avaudiosessioncategoryplayandrecord)).

<details>
<summary>Code sample</summary>

```dart
  /// Configures the app's audio session so that it's optimized for voice communication.
  Future<void> configureAudioSession() async {
    try {
      AudioSession audioSession = await AudioSession.instance;

      await audioSession.configure(AudioSessionConfiguration(
        androidAudioAttributes: const AndroidAudioAttributes(
          // https://developer.android.com/reference/android/media/AudioAttributes#CONTENT_TYPE_SPEECH.
          contentType: AndroidAudioContentType.speech,

          // https://source.android.com/docs/core/audio/attributes#flags.
          flags: AndroidAudioFlags.none,

          // https://developer.android.com/reference/android/media/AudioAttributes#USAGE_VOICE_COMMUNICATION.
          usage: AndroidAudioUsage.voiceCommunication,
        ),

        // https://developer.android.com/reference/android/media/AudioManager#AUDIOFOCUS_GAIN.
        androidAudioFocusGainType: AndroidAudioFocusGainType.gain,

        // https://developer.apple.com/documentation/avfaudio/avaudiosessioncategoryplayandrecord.
        avAudioSessionCategory: AVAudioSessionCategory.playAndRecord,

        // https://developer.apple.com/documentation/avfaudio/avaudiosession/categoryoptions.
        avAudioSessionCategoryOptions: AVAudioSessionCategoryOptions.allowAirPlay |
            AVAudioSessionCategoryOptions.allowBluetooth |
            AVAudioSessionCategoryOptions.allowBluetoothA2dp |
            AVAudioSessionCategoryOptions.defaultToSpeaker |
            AVAudioSessionCategoryOptions.duckOthers,

        // https://developer.apple.com/documentation/avfaudio/avaudiosessionmodevoicechat.
        avAudioSessionMode: AVAudioSessionMode.voiceChat,

        // https://developer.apple.com/documentation/avfaudio/avaudiosessionroutesharingpolicy/avaudiosessionroutesharingpolicydefault.
        avAudioSessionRouteSharingPolicy: AVAudioSessionRouteSharingPolicy.defaultPolicy,

        // https://developer.apple.com/documentation/avfaudio/avaudiosession/setactiveoptions.
        avAudioSessionSetActiveOptions: AVAudioSessionSetActiveOptions.none,
      ));
    } catch (e, s) {
      _log.shout('failed to configure audio session', e, s);
    }
  }
```
</details>