### PR TITLE
Handle Platform Exception on addCandidate

### DIFF
--- a/lib/src/native/rtc_peerconnection_impl.dart
+++ b/lib/src/native/rtc_peerconnection_impl.dart
@@ -360,10 +360,14 @@ class RTCPeerConnectionNative extends RTCPeerConnection {
 
   @override
   Future<void> addCandidate(RTCIceCandidate candidate) async {
-    await WebRTC.invokeMethod('addCandidate', <String, dynamic>{
-      'peerConnectionId': _peerConnectionId,
-      'candidate': candidate.toMap(),
-    });
+    try {
+      await WebRTC.invokeMethod('addCandidate', <String, dynamic>{
+        'peerConnectionId': _peerConnectionId,
+        'candidate': candidate.toMap(),
+      });
+    } on PlatformException catch (e) {
+      throw 'Unable to RTCPeerConnection::addCandidate: ${e.message}';
+    }
   }
 
   @override


### PR DESCRIPTION
iOS throws 
[VERBOSE-2:ui_dart_state.cc(198)] Unhandled Exception: PlatformException(AddIceCandidateFailed, Error The remote description was null, null, null) sometimes.
and this change will help to handle it.