### PR TITLE
Keep the audio switch after stopping

### DIFF
--- a/android/src/main/java/com/cloudwebrtc/webrtc/FlutterWebRTCPlugin.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/FlutterWebRTCPlugin.java
@@ -129,7 +129,6 @@ public class FlutterWebRTCPlugin implements FlutterPlugin, ActivityAware, EventC
         if (AudioSwitchManager.instance != null) {
             Log.d(TAG, "Stopping the audio manager...");
             AudioSwitchManager.instance.stop();
-            AudioSwitchManager.instance = null;
         }
     }
 


### PR DESCRIPTION
The audio switch is nullified when stopping which disallows further use after a single stop.
Keeping the reference doesn't cause any memory leaks as the encapsulated fields are removed on stop.