### PR TITLE
Enhance RTC video view with placeholder builder property

### DIFF
--- a/lib/src/native/rtc_video_renderer_impl.dart
+++ b/lib/src/native/rtc_video_renderer_impl.dart
@@ -119,7 +119,7 @@ class RTCVideoRenderer extends ValueNotifier<RTCVideoValue>
   }
 
   @override
-  bool get renderVideo => srcObject != null;
+  bool get renderVideo => _textureId != null && _srcObject != null;
 
   @override
   bool get muted => _srcObject?.getAudioTracks()[0].muted ?? true;

--- a/lib/src/native/rtc_video_view_impl.dart
+++ b/lib/src/native/rtc_video_view_impl.dart
@@ -55,13 +55,12 @@ class RTCVideoView extends StatelessWidget {
               child: Transform(
                 transform: Matrix4.identity()..rotateY(mirror ? -pi : 0.0),
                 alignment: FractionalOffset.center,
-                child:
-                    videoRenderer.textureId != null && videoRenderer.renderVideo
-                        ? Texture(
-                            textureId: videoRenderer.textureId!,
-                            filterQuality: filterQuality,
-                          )
-                        : placeholderBuilder?.call(context) ?? Container(),
+                child: videoRenderer.renderVideo
+                    ? Texture(
+                        textureId: videoRenderer.textureId!,
+                        filterQuality: filterQuality,
+                      )
+                    : placeholderBuilder?.call(context) ?? Container(),
               ),
             ),
           ),

--- a/lib/src/native/rtc_video_view_impl.dart
+++ b/lib/src/native/rtc_video_view_impl.dart
@@ -13,12 +13,14 @@ class RTCVideoView extends StatelessWidget {
     this.objectFit = RTCVideoViewObjectFit.RTCVideoViewObjectFitContain,
     this.mirror = false,
     this.filterQuality = FilterQuality.low,
+    this.placeholderBuilder,
   }) : super(key: key);
 
   final RTCVideoRenderer _renderer;
   final RTCVideoViewObjectFit objectFit;
   final bool mirror;
   final FilterQuality filterQuality;
+  final WidgetBuilder? placeholderBuilder;
 
   RTCVideoRenderer get videoRenderer => _renderer;
 
@@ -26,10 +28,10 @@ class RTCVideoView extends StatelessWidget {
   Widget build(BuildContext context) {
     return LayoutBuilder(
         builder: (BuildContext context, BoxConstraints constraints) =>
-            _buildVideoView(constraints));
+            _buildVideoView(context, constraints));
   }
 
-  Widget _buildVideoView(BoxConstraints constraints) {
+  Widget _buildVideoView(BuildContext context, BoxConstraints constraints) {
     return Center(
       child: Container(
         width: constraints.maxWidth,
@@ -53,13 +55,13 @@ class RTCVideoView extends StatelessWidget {
               child: Transform(
                 transform: Matrix4.identity()..rotateY(mirror ? -pi : 0.0),
                 alignment: FractionalOffset.center,
-                child: videoRenderer.textureId != null &&
-                        videoRenderer.srcObject != null
-                    ? Texture(
-                        textureId: videoRenderer.textureId!,
-                        filterQuality: filterQuality,
-                      )
-                    : Container(),
+                child:
+                    videoRenderer.textureId != null && videoRenderer.renderVideo
+                        ? Texture(
+                            textureId: videoRenderer.textureId!,
+                            filterQuality: filterQuality,
+                          )
+                        : placeholderBuilder?.call(context) ?? Container(),
               ),
             ),
           ),

--- a/lib/src/web/rtc_video_view_impl.dart
+++ b/lib/src/web/rtc_video_view_impl.dart
@@ -15,12 +15,14 @@ class RTCVideoView extends StatefulWidget {
     this.objectFit = RTCVideoViewObjectFit.RTCVideoViewObjectFitContain,
     this.mirror = false,
     this.filterQuality = FilterQuality.low,
+    this.placeholderBuilder,
   }) : super(key: key);
 
   final RTCVideoRenderer _renderer;
   final RTCVideoViewObjectFit objectFit;
   final bool mirror;
   final FilterQuality filterQuality;
+  final WidgetBuilder? placeholderBuilder;
 
   @override
   RTCVideoViewState createState() => RTCVideoViewState();
@@ -83,7 +85,7 @@ class RTCVideoViewState extends State<RTCVideoView> {
             height: constraints.maxHeight,
             child: widget._renderer.renderVideo
                 ? buildVideoElementView()
-                : Container(),
+                : widget.placeholderBuilder?.call(context) ?? Container(),
           ),
         );
       },


### PR DESCRIPTION
This tiny enhancement of `RTCVideoView` allows simplifying add meaningful placeholder widget while `RTCVideoRenderer` is preparing/initialing.

Also, I am going to use it within integration tests that automate app screenshots creation.