### PR TITLE
Fix crash when calling captureFrame on a video track on android (#1129)

### DIFF
--- a/android/src/main/java/com/cloudwebrtc/webrtc/record/FrameCapturer.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/record/FrameCapturer.java
@@ -52,7 +52,6 @@ public class FrameCapturer implements VideoSink {
             i420Buffer.getStrideU(),
             i420Buffer.getStrideV()
         };
-        i420Buffer.release();
         final int chromaWidth = (width + 1) / 2;
         final int chromaHeight = (height + 1) / 2;
         final int minSize = width * height + chromaWidth * chromaHeight * 2;
@@ -65,6 +64,7 @@ public class FrameCapturer implements VideoSink {
             height,
             strides
         );
+        i420Buffer.release();
         videoFrame.release();
         new Handler(Looper.getMainLooper()).post(() -> {
             videoTrack.removeSink(this);


### PR DESCRIPTION
The crash only happens on some Android devices (reproduced on Google Pixel 4).