### PR TITLE
fixed audio device name buffer size

### DIFF
--- a/common/cpp/src/flutter_media_stream.cc
+++ b/common/cpp/src/flutter_media_stream.cc
@@ -298,8 +298,8 @@ void FlutterMediaStream::GetSources(std::unique_ptr<MethodResultProxy> result) {
   EncodableList sources;
 
   int nb_audio_devices = base_->audio_device_->RecordingDevices();
-  char strNameUTF8[128];
-  char strGuidUTF8[128];
+  char strNameUTF8[256];
+  char strGuidUTF8[256];
 
   for (uint16_t i = 0; i < nb_audio_devices; i++) {
     base_->audio_device_->RecordingDeviceName(i, strNameUTF8, strGuidUTF8);


### PR DESCRIPTION
Buffer size is unified with other places in this file. On linux default device name size can exceed 128 bytes, which leads to buffer overflow.