### PR TITLE
Buffer overflow, while requesting device name

### DIFF
--- a/common/cpp/src/flutter_media_stream.cc
+++ b/common/cpp/src/flutter_media_stream.cc
@@ -298,15 +298,15 @@ void FlutterMediaStream::GetSources(std::unique_ptr<MethodResultProxy> result) {
   EncodableList sources;
 
   int nb_audio_devices = base_->audio_device_->RecordingDevices();
-  char strNameUTF8[RTCAudioDevice::kAdmMaxDeviceNameSize];
-  char strGuidUTF8[RTCAudioDevice::kAdmMaxGuidSize];
+  char strNameUTF8[RTCAudioDevice::kAdmMaxDeviceNameSize + 1] = {0};
+  char strGuidUTF8[RTCAudioDevice::kAdmMaxGuidSize + 1] = {0};
 
   for (uint16_t i = 0; i < nb_audio_devices; i++) {
     base_->audio_device_->RecordingDeviceName(i, strNameUTF8, strGuidUTF8);
     EncodableMap audio;
-    audio[EncodableValue("label")] = EncodableValue(std::string(strNameUTF8, RTCAudioDevice::kAdmMaxDeviceNameSize));
+    audio[EncodableValue("label")] = EncodableValue(std::string(strNameUTF8));
     audio[EncodableValue("deviceId")] =
-        EncodableValue(std::string(strGuidUTF8, RTCAudioDevice::kAdmMaxGuidSize));
+        EncodableValue(std::string(strGuidUTF8));
     audio[EncodableValue("facing")] = "";
     audio[EncodableValue("kind")] = "audioinput";
     sources.push_back(EncodableValue(audio));
@@ -316,9 +316,9 @@ void FlutterMediaStream::GetSources(std::unique_ptr<MethodResultProxy> result) {
   for (uint16_t i = 0; i < nb_audio_devices; i++) {
     base_->audio_device_->PlayoutDeviceName(i, strNameUTF8, strGuidUTF8);
     EncodableMap audio;
-    audio[EncodableValue("label")] = EncodableValue(std::string(strNameUTF8, RTCAudioDevice::kAdmMaxDeviceNameSize));
+    audio[EncodableValue("label")] = EncodableValue(std::string(strNameUTF8));
     audio[EncodableValue("deviceId")] =
-        EncodableValue(std::string(strGuidUTF8, RTCAudioDevice::kAdmMaxGuidSize));
+        EncodableValue(std::string(strGuidUTF8));
     audio[EncodableValue("facing")] = "";
     audio[EncodableValue("kind")] = "audiooutput";
     sources.push_back(EncodableValue(audio));
@@ -328,9 +328,9 @@ void FlutterMediaStream::GetSources(std::unique_ptr<MethodResultProxy> result) {
   for (int i = 0; i < nb_video_devices; i++) {
     base_->video_device_->GetDeviceName(i, strNameUTF8, 128, strGuidUTF8, 128);
     EncodableMap video;
-    video[EncodableValue("label")] = EncodableValue(std::string(strNameUTF8, 128));
+    video[EncodableValue("label")] = EncodableValue(std::string(strNameUTF8));
     video[EncodableValue("deviceId")] =
-        EncodableValue(std::string(strGuidUTF8, 128));
+        EncodableValue(std::string(strGuidUTF8));
     video[EncodableValue("facing")] = i == 1 ? "front" : "back";
     video[EncodableValue("kind")] = "videoinput";
     sources.push_back(EncodableValue(video));

--- a/common/cpp/src/flutter_media_stream.cc
+++ b/common/cpp/src/flutter_media_stream.cc
@@ -298,8 +298,8 @@ void FlutterMediaStream::GetSources(std::unique_ptr<MethodResultProxy> result) {
   EncodableList sources;
 
   int nb_audio_devices = base_->audio_device_->RecordingDevices();
-  char strNameUTF8[128];
-  char strGuidUTF8[128];
+  char strNameUTF8[256];
+  char strGuidUTF8[256];
 
   for (uint16_t i = 0; i < nb_audio_devices; i++) {
     base_->audio_device_->RecordingDeviceName(i, strNameUTF8, strGuidUTF8);

--- a/common/cpp/src/flutter_media_stream.cc
+++ b/common/cpp/src/flutter_media_stream.cc
@@ -298,15 +298,15 @@ void FlutterMediaStream::GetSources(std::unique_ptr<MethodResultProxy> result) {
   EncodableList sources;
 
   int nb_audio_devices = base_->audio_device_->RecordingDevices();
-  char strNameUTF8[256];
-  char strGuidUTF8[256];
+  char strNameUTF8[RTCAudioDevice::kAdmMaxDeviceNameSize];
+  char strGuidUTF8[RTCAudioDevice::kAdmMaxGuidSize];
 
   for (uint16_t i = 0; i < nb_audio_devices; i++) {
     base_->audio_device_->RecordingDeviceName(i, strNameUTF8, strGuidUTF8);
     EncodableMap audio;
-    audio[EncodableValue("label")] = EncodableValue(std::string(strNameUTF8));
+    audio[EncodableValue("label")] = EncodableValue(std::string(strNameUTF8, RTCAudioDevice::kAdmMaxDeviceNameSize));
     audio[EncodableValue("deviceId")] =
-        EncodableValue(std::string(strGuidUTF8));
+        EncodableValue(std::string(strGuidUTF8, RTCAudioDevice::kAdmMaxGuidSize));
     audio[EncodableValue("facing")] = "";
     audio[EncodableValue("kind")] = "audioinput";
     sources.push_back(EncodableValue(audio));
@@ -316,9 +316,9 @@ void FlutterMediaStream::GetSources(std::unique_ptr<MethodResultProxy> result) {
   for (uint16_t i = 0; i < nb_audio_devices; i++) {
     base_->audio_device_->PlayoutDeviceName(i, strNameUTF8, strGuidUTF8);
     EncodableMap audio;
-    audio[EncodableValue("label")] = EncodableValue(std::string(strNameUTF8));
+    audio[EncodableValue("label")] = EncodableValue(std::string(strNameUTF8, RTCAudioDevice::kAdmMaxDeviceNameSize));
     audio[EncodableValue("deviceId")] =
-        EncodableValue(std::string(strGuidUTF8));
+        EncodableValue(std::string(strGuidUTF8, RTCAudioDevice::kAdmMaxGuidSize));
     audio[EncodableValue("facing")] = "";
     audio[EncodableValue("kind")] = "audiooutput";
     sources.push_back(EncodableValue(audio));
@@ -328,9 +328,9 @@ void FlutterMediaStream::GetSources(std::unique_ptr<MethodResultProxy> result) {
   for (int i = 0; i < nb_video_devices; i++) {
     base_->video_device_->GetDeviceName(i, strNameUTF8, 128, strGuidUTF8, 128);
     EncodableMap video;
-    video[EncodableValue("label")] = EncodableValue(std::string(strNameUTF8));
+    video[EncodableValue("label")] = EncodableValue(std::string(strNameUTF8, 128));
     video[EncodableValue("deviceId")] =
-        EncodableValue(std::string(strGuidUTF8));
+        EncodableValue(std::string(strGuidUTF8, 128));
     video[EncodableValue("facing")] = i == 1 ? "front" : "back";
     video[EncodableValue("kind")] = "videoinput";
     sources.push_back(EncodableValue(video));


### PR DESCRIPTION
When PlayoutDeviceName or RecordingDeviceName is used on linux, default device name can exceed default buffer size 128 Bytes. In this case WebRTC returns no null terminated buffer. And building string as
std::string(strNamUTF8) leads to usage of memory outside of buffer.
This unitialized memory can't then be decoded bu flutter code.