### PR TITLE
iOS Audio bug fix

### DIFF
--- a/common/darwin/Classes/AudioUtils.m
+++ b/common/darwin/Classes/AudioUtils.m
@@ -105,10 +105,15 @@
 }
 
 + (void)deactiveRtcAudioSession {
-  NSError* error = nil;
-  [[AVAudioSession sharedInstance] setActive:NO
-                                 withOptions:AVAudioSessionSetActiveOptionNotifyOthersOnDeactivation
-                                       error:&error];
+    NSError* error = nil;
+    RTCAudioSession* session = [RTCAudioSession sharedInstance];
+    [session lockForConfiguration];
+    BOOL success = [session setActive:NO error:&error];
+    if (!success)
+        NSLog(@"RTC Audio session deactive failed: %@", error);
+    else
+        NSLog(@"RTC AudioSession deactive is successful ");
+    [session unlockForConfiguration];
 }
 
 @end


### PR DESCRIPTION
- 问题：

原来的方法在createStream成功后，但未接通通话前异常断开，或者本身业务设计有接听界面，此时用户断开连接，会导致下次通话无法正常播放声音。

- 修复：

使用RTCAudioSession关闭声音通道，这样无论何种情况下，下次通话声音都正常播放。