### PR TITLE
Fix: After the window is closed, the old source still exists

### DIFF
--- a/lib/src/native/desktop_capturer_impl.dart
+++ b/lib/src/native/desktop_capturer_impl.dart
@@ -146,6 +146,7 @@ class DesktopCapturerNative extends DesktopCapturer {
   @override
   Future<List<DesktopCapturerSource>> getSources(
       {required List<SourceType> types, ThumbnailSize? thumbnailSize}) async {
+    _sources.clear();
     final response = await WebRTC.invokeMethod(
       'getDesktopSources',
       <String, dynamic>{


### PR DESCRIPTION
When the sharing window is opened, the newly added page will be displayed in the window. However, after closing the application to be shared and reopening the sharing window, the application interface still exists