### PR TITLE
BugFix: iOS audio ouptut switching when toggling mic

### DIFF
--- a/common/darwin/Classes/AudioUtils.m
+++ b/common/darwin/Classes/AudioUtils.m
@@ -15,7 +15,7 @@
     config.category = AVAudioSessionCategoryPlayAndRecord;
     config.categoryOptions =
         AVAudioSessionCategoryOptionAllowBluetooth | AVAudioSessionCategoryOptionAllowBluetoothA2DP;
-    config.mode = AVAudioSessionModeVoiceChat;
+    config.mode = AVAudioSessionModeVideoChat;
 
     [session lockForConfiguration];
     [session setCategory:config.category withOptions:config.categoryOptions error:nil];


### PR DESCRIPTION
This is a PR to fix for Issue #1284.

Choosing a `AVAudioSessionModeVideoChat` as mode while using `PlayAndRecord` solves the issue of audio being switched to earpiece once the mic is toggled on and vice-versa. 