### PR TITLE
Fix track lookup in the platform specific code for Android and iOS

### DIFF
--- a/common/darwin/Classes/FlutterWebRTCPlugin.m
+++ b/common/darwin/Classes/FlutterWebRTCPlugin.m
@@ -275,8 +275,9 @@
     NSDictionary* argsMap = call.arguments;
     NSString* path = argsMap[@"path"];
     NSString* trackId = argsMap[@"trackId"];
+    NSString* peerConnectionId = argsMap[@"peerConnectionId"];
 
-    RTCMediaStreamTrack* track = [self trackForId:trackId];
+    RTCMediaStreamTrack* track = [self trackForId:trackId peerConnectionId: peerConnectionId];
     if (track != nil && [track isKindOfClass:[RTCVideoTrack class]]) {
       RTCVideoTrack* videoTrack = (RTCVideoTrack*)track;
       [self mediaStreamTrackCaptureFrame:videoTrack toPath:path result:result];
@@ -465,7 +466,9 @@
     NSDictionary* argsMap = call.arguments;
     NSString* trackId = argsMap[@"trackId"];
     NSNumber* enabled = argsMap[@"enabled"];
-    RTCMediaStreamTrack* track = [self trackForId:trackId];
+    NSString* peerConnectionId = argsMap[@"peerConnectionId"];
+
+    RTCMediaStreamTrack* track = [self trackForId:trackId peerConnectionId: peerConnectionId];
     if (track != nil) {
       track.isEnabled = enabled.boolValue;
     }
@@ -477,7 +480,7 @@
 
     RTCMediaStream* stream = self.localStreams[streamId];
     if (stream) {
-      RTCMediaStreamTrack* track = [self trackForId:trackId];
+      RTCMediaStreamTrack* track = [self trackForId:trackId peerConnectionId: nil];
       if (track != nil) {
         if ([track isKindOfClass:[RTCAudioTrack class]]) {
           RTCAudioTrack* audioTrack = (RTCAudioTrack*)track;
@@ -694,7 +697,9 @@
     NSDictionary* argsMap = call.arguments;
     NSString* trackId = argsMap[@"trackId"];
     NSNumber* volume = argsMap[@"volume"];
-    RTCMediaStreamTrack* track = self.localTracks[trackId];
+    NSString* peerConnectionId = argsMap[@"peerConnectionId"];
+
+    RTCMediaStreamTrack* track = [self trackForId:trackId peerConnectionId: peerConnectionId];
     if (track != nil && [track isKindOfClass:[RTCAudioTrack class]]) {
       RTCAudioTrack* audioTrack = (RTCAudioTrack*)track;
       RTCAudioSource* audioSource = audioTrack.source;
@@ -786,7 +791,7 @@
       return;
     }
 
-    RTCMediaStreamTrack* track = [self trackForId:trackId];
+    RTCMediaStreamTrack* track = [self trackForId:trackId peerConnectionId: nil];
     if (track == nil) {
       result([FlutterError errorWithCode:[NSString stringWithFormat:@"%@Failed", call.method]
                                  message:[NSString stringWithFormat:@"Error: track not found!"]
@@ -840,7 +845,7 @@
     RTCRtpTransceiver* transceiver = nil;
     BOOL hasAudio = NO;
     if (trackId != nil) {
-      RTCMediaStreamTrack* track = [self trackForId:trackId];
+      RTCMediaStreamTrack* track = [self trackForId:trackId peerConnectionId: nil];
       if (transceiverInit != nil) {
         RTCRtpTransceiverInit* init = [self mapToTransceiverInit:transceiverInit];
         transceiver = [peerConnection addTransceiverWithTrack:track init:init];
@@ -999,7 +1004,7 @@
     }
     RTCMediaStreamTrack* track = nil;
     if ([trackId length] > 0) {
-      track = [self trackForId:trackId];
+      track = [self trackForId:trackId peerConnectionId: nil];
       if (track == nil) {
         result([FlutterError errorWithCode:[NSString stringWithFormat:@"%@Failed", call.method]
                                    message:[NSString stringWithFormat:@"Error: track not found!"]
@@ -1031,7 +1036,7 @@
     }
     RTCMediaStreamTrack* track = nil;
     if ([trackId length] > 0) {
-      track = [self trackForId:trackId];
+      track = [self trackForId:trackId peerConnectionId: nil];
       if (track == nil) {
         result([FlutterError errorWithCode:[NSString stringWithFormat:@"%@Failed", call.method]
                                    message:[NSString stringWithFormat:@"Error: track not found!"]
@@ -1215,10 +1220,14 @@
   return stream;
 }
 
-- (RTCMediaStreamTrack*)trackForId:(NSString*)trackId {
+- (RTCMediaStreamTrack*)trackForId:(NSString*)trackId peerConnectionId:(NSString*)peerConnectionId {
   RTCMediaStreamTrack* track = _localTracks[trackId];
   if (!track) {
-    for (RTCPeerConnection* peerConnection in _peerConnections.allValues) {
+    for (NSString* currentId in _peerConnections.allKeys) { 
+      if (peerConnectionId && [currentId isEqualToString: peerConnectionId] == false) {
+        continue;
+      }
+      RTCPeerConnection* peerConnection = _peerConnections[currentId];
       track = peerConnection.remoteTracks[trackId];
       if (!track) {
         for (RTCRtpTransceiver* transceiver in peerConnection.transceivers) {

--- a/lib/src/helper.dart
+++ b/lib/src/helper.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
+import '../src/native/media_stream_track_impl.dart';
+
 import '../flutter_webrtc.dart';
 
 class Helper {
@@ -125,7 +127,8 @@ class Helper {
       } else {
         await WebRTC.invokeMethod(
           'setVolume',
-          <String, dynamic>{'trackId': track.id, 'volume': volume},
+          <String, dynamic>{'trackId': track.id, 'volume': volume,
+          'peerConnectionId': track is MediaStreamTrackNative ? track.peerConnectionId : null}
         );
       }
     }

--- a/lib/src/native/media_recorder_impl.dart
+++ b/lib/src/native/media_recorder_impl.dart
@@ -3,6 +3,8 @@ import 'dart:math';
 
 import 'package:webrtc_interface/webrtc_interface.dart';
 
+import '../native/media_stream_track_impl.dart';
+
 import 'utils.dart';
 
 class MediaRecorderNative extends MediaRecorder {
@@ -22,7 +24,8 @@ class MediaRecorderNative extends MediaRecorder {
       'path': path,
       if (audioChannel != null) 'audioChannel': audioChannel.index,
       if (videoTrack != null) 'videoTrackId': videoTrack.id,
-      'recorderId': _recorderId
+      'recorderId': _recorderId,
+      'peerConnectionId': videoTrack is MediaStreamTrackNative ? videoTrack.peerConnectionId : null
     });
   }
 

--- a/lib/src/native/media_stream_impl.dart
+++ b/lib/src/native/media_stream_impl.dart
@@ -21,13 +21,13 @@ class MediaStreamNative extends MediaStream {
 
     for (var track in audioTracks) {
       _audioTracks.add(MediaStreamTrackNative(
-          track['id'], track['label'], track['kind'], track['enabled']));
+          track['id'], track['label'], track['kind'], track['enabled'], ownerTag));
     }
 
     _videoTracks.clear();
     for (var track in videoTracks) {
       _videoTracks.add(MediaStreamTrackNative(
-          track['id'], track['label'], track['kind'], track['enabled']));
+          track['id'], track['label'], track['kind'], track['enabled'], ownerTag));
     }
   }
 

--- a/lib/src/native/media_stream_track_impl.dart
+++ b/lib/src/native/media_stream_track_impl.dart
@@ -9,23 +9,26 @@ import '../helper.dart';
 import 'utils.dart';
 
 class MediaStreamTrackNative extends MediaStreamTrack {
-  MediaStreamTrackNative(this._trackId, this._label, this._kind, this._enabled);
+  MediaStreamTrackNative(this._trackId, this._label, this._kind, this._enabled, this._peerConnectionId);
 
-  factory MediaStreamTrackNative.fromMap(Map<dynamic, dynamic> map) {
+  factory MediaStreamTrackNative.fromMap(Map<dynamic, dynamic> map, String peerConnectionId) {
     return MediaStreamTrackNative(
-        map['id'], map['label'], map['kind'], map['enabled']);
+        map['id'], map['label'], map['kind'], map['enabled'], peerConnectionId);
   }
   final String _trackId;
   final String _label;
   final String _kind;
+  final String _peerConnectionId;
   bool _enabled;
 
   bool _muted = false;
 
+  String get peerConnectionId => _peerConnectionId;
+
   @override
   set enabled(bool enabled) {
     WebRTC.invokeMethod('mediaStreamTrackSetEnable',
-        <String, dynamic>{'trackId': _trackId, 'enabled': enabled});
+        <String, dynamic>{'trackId': _trackId, 'enabled': enabled, 'peerConnectionId': _peerConnectionId});
     _enabled = enabled;
 
     if (kind == 'audio') {
@@ -77,6 +80,7 @@ class MediaStreamTrackNative extends MediaStreamTrack {
       'captureFrame',
       <String, dynamic>{
         'trackId': _trackId,
+        'peerConnectionId': _peerConnectionId,
         'path': '${filePath.path}/captureFrame.png'
       },
     );

--- a/lib/src/native/rtc_peerconnection_impl.dart
+++ b/lib/src/native/rtc_peerconnection_impl.dart
@@ -118,7 +118,7 @@ class RTCPeerConnectionNative extends RTCPeerConnection {
         Map<dynamic, dynamic> track = map['track'];
 
         var newTrack = MediaStreamTrackNative(
-            track['id'], track['label'], track['kind'], track['enabled']);
+            track['id'], track['label'], track['kind'], track['enabled'], _peerConnectionId);
         String kind = track['kind'];
 
         var stream =
@@ -177,7 +177,7 @@ class RTCPeerConnectionNative extends RTCPeerConnection {
             receiver: RTCRtpReceiverNative.fromMap(map['receiver'],
                 peerConnectionId: _peerConnectionId),
             streams: streams,
-            track: MediaStreamTrackNative.fromMap(map['track']),
+            track: MediaStreamTrackNative.fromMap(map['track'], _peerConnectionId),
             transceiver: transceiver));
         break;
 

--- a/lib/src/native/rtc_rtp_receiver_impl.dart
+++ b/lib/src/native/rtc_rtp_receiver_impl.dart
@@ -11,7 +11,7 @@ class RTCRtpReceiverNative extends RTCRtpReceiver {
 
   factory RTCRtpReceiverNative.fromMap(Map<dynamic, dynamic> map,
       {required String peerConnectionId}) {
-    var track = MediaStreamTrackNative.fromMap(map['track']);
+    var track = MediaStreamTrackNative.fromMap(map['track'], peerConnectionId);
     var parameters = RTCRtpParameters.fromMap(map['rtpParameters']);
     return RTCRtpReceiverNative(
         map['receiverId'], track, parameters, peerConnectionId);

--- a/lib/src/native/rtc_rtp_sender_impl.dart
+++ b/lib/src/native/rtc_rtp_sender_impl.dart
@@ -19,7 +19,7 @@ class RTCRtpSenderNative extends RTCRtpSender {
     return RTCRtpSenderNative(
         map['senderId'],
         (trackMap.isNotEmpty)
-            ? MediaStreamTrackNative.fromMap(map['track'])
+            ? MediaStreamTrackNative.fromMap(map['track'], peerConnectionId)
             : null,
         RTCDTMFSenderNative(peerConnectionId, map['senderId']),
         RTCRtpParameters.fromMap(map['rtpParameters']),


### PR DESCRIPTION
All operations on track objects in the flutter API just send the track id to the platform specific code without the additional information which peer connection the track belongs to. This leads to methods like captureFrame() being called on the wrong track if there are tracks with the same id in more than one peer connection.

Fixes #469