### PR TITLE
[Windows/Linux] Fix uneffective RTPTransceiver::GetCurrentDirection

### DIFF
--- a/common/cpp/src/flutter_peerconnection.cc
+++ b/common/cpp/src/flutter_peerconnection.cc
@@ -685,6 +685,7 @@ void FlutterPeerConnection::RtpTransceiverStop(
   auto transceiver = getRtpTransceiverById(pc, rtpTransceiverId);
   if (nullptr == transceiver.get()) {
     result_ptr->Error("rtpTransceiverStop", "transceiver is null");
+    return;
   }
   transceiver->StopInternal();
   result_ptr->Success();
@@ -700,6 +701,7 @@ void FlutterPeerConnection::RtpTransceiverGetCurrentDirection(
   if (nullptr == transceiver.get()) {
     result_ptr->Error("rtpTransceiverGetCurrentDirection",
                       "transceiver is null");
+    return;
   }
   EncodableMap map;
   map[EncodableValue("result")] =

--- a/common/cpp/src/flutter_webrtc.cc
+++ b/common/cpp/src/flutter_webrtc.cc
@@ -854,7 +854,7 @@ void FlutterWebRTC::HandleMethodCall(
       return;
     }
 
-    const std::string rtpTransceiverId = findString(params, "rtpTransceiverId");
+    const std::string rtpTransceiverId = findString(params, "transceiverId");
     if (0 < rtpTransceiverId.size()) {
       if (pc == nullptr) {
         result->Error("rtpTransceiverGetCurrentDirection",


### PR DESCRIPTION
If `RTPTransceiver` is null, GetCurrentDirection crashes on Windows