### PR TITLE
[Windows/Linux] `RTPtransceiver::getCurrentDirection` returns correct value

### DIFF
--- a/common/cpp/src/flutter_peerconnection.cc
+++ b/common/cpp/src/flutter_peerconnection.cc
@@ -705,7 +705,7 @@ void FlutterPeerConnection::RtpTransceiverGetCurrentDirection(
   }
   EncodableMap map;
   map[EncodableValue("result")] =
-      EncodableValue(transceiverDirectionString(transceiver->direction()));
+      EncodableValue(transceiverDirectionString(transceiver->current_direction()));
   result_ptr->Success(EncodableValue(map));
 }
 
@@ -1348,12 +1348,14 @@ scoped_refptr<RTCMediaTrack> FlutterPeerConnectionObserver::MediaTrackForId(
     auto remoteStream = (*it).second;
     auto audio_tracks = remoteStream->audio_tracks();
     for (auto track : audio_tracks.std_vector()) {
+      std::string track_id = track->id().std_string();
       if (track->id().std_string() == id) {
         return track;
       }
     }
     auto video_tracks = remoteStream->video_tracks();
     for (auto track : video_tracks.std_vector()) {
+      std::string track_id = track->id().std_string();
       if (track->id().std_string() == id) {
         return track;
       }

--- a/common/cpp/src/flutter_peerconnection.cc
+++ b/common/cpp/src/flutter_peerconnection.cc
@@ -1348,14 +1348,12 @@ scoped_refptr<RTCMediaTrack> FlutterPeerConnectionObserver::MediaTrackForId(
     auto remoteStream = (*it).second;
     auto audio_tracks = remoteStream->audio_tracks();
     for (auto track : audio_tracks.std_vector()) {
-      std::string track_id = track->id().std_string();
       if (track->id().std_string() == id) {
         return track;
       }
     }
     auto video_tracks = remoteStream->video_tracks();
     for (auto track : video_tracks.std_vector()) {
-      std::string track_id = track->id().std_string();
       if (track->id().std_string() == id) {
         return track;
       }


### PR DESCRIPTION
libwebrtc implementation wasn't calling `RTCRtpTransceiver::current_direction`