### PR TITLE
Add implementation to MediaStreamTrack.captureFrame() for linux

### DIFF
--- a/common/cpp/include/flutter_frame_capturer.h
+++ b/common/cpp/include/flutter_frame_capturer.h
@@ -20,12 +20,15 @@ class FlutterFrameCapturer
 
   virtual void OnFrame(scoped_refptr<RTCVideoFrame> frame) override;
 
-  void Capture(std::unique_ptr<MethodResultProxy> result);
+  void CaptureFrame(std::unique_ptr<MethodResultProxy> result);
 
  private:
   RTCVideoTrack* track_;
   std::string path_;
   std::mutex mutex_;
+  scoped_refptr<RTCVideoFrame> frame_;
+
+  bool SaveFrame();
 };
 
 }  // namespace flutter_webrtc_plugin

--- a/common/cpp/include/flutter_frame_capturer.h
+++ b/common/cpp/include/flutter_frame_capturer.h
@@ -1,5 +1,5 @@
-#ifndef FLUTTER_WEBRTC_RTC_VIDEO_RENDERER_HXX
-#define FLUTTER_WEBRTC_RTC_VIDEO_RENDERER_HXX
+#ifndef FLUTTER_WEBRTC_RTC_FRAME_CAPTURER_HXX
+#define FLUTTER_WEBRTC_RTC_FRAME_CAPTURER_HXX
 
 #include "flutter_common.h"
 #include "flutter_webrtc_base.h"
@@ -33,4 +33,4 @@ class FlutterFrameCapturer
 
 }  // namespace flutter_webrtc_plugin
 
-#endif  // !FLUTTER_WEBRTC_RTC_VIDEO_RENDERER_HXX
+#endif  // !FLUTTER_WEBRTC_RTC_FRAME_CAPTURER_HXX

--- a/common/cpp/include/flutter_frame_capturer.h
+++ b/common/cpp/include/flutter_frame_capturer.h
@@ -1,0 +1,33 @@
+#ifndef FLUTTER_WEBRTC_RTC_VIDEO_RENDERER_HXX
+#define FLUTTER_WEBRTC_RTC_VIDEO_RENDERER_HXX
+
+#include "flutter_common.h"
+#include "flutter_webrtc_base.h"
+
+#include "rtc_video_frame.h"
+#include "rtc_video_renderer.h"
+
+#include <mutex>
+
+namespace flutter_webrtc_plugin {
+
+using namespace libwebrtc;
+
+class FlutterFrameCapturer
+    : public RTCVideoRenderer<scoped_refptr<RTCVideoFrame>> {
+ public:
+  FlutterFrameCapturer(RTCVideoTrack* track, std::string path);
+
+  virtual void OnFrame(scoped_refptr<RTCVideoFrame> frame) override;
+
+  void Capture(std::unique_ptr<MethodResultProxy> result);
+
+ private:
+  RTCVideoTrack* track_;
+  std::string path_;
+  std::mutex mutex_;
+};
+
+}  // namespace flutter_webrtc_plugin
+
+#endif  // !FLUTTER_WEBRTC_RTC_VIDEO_RENDERER_HXX

--- a/common/cpp/src/flutter_frame_capturer.cc
+++ b/common/cpp/src/flutter_frame_capturer.cc
@@ -1,3 +1,7 @@
+#ifdef _MSC_VER
+#define _CRT_SECURE_NO_WARNINGS
+#endif
+
 #include "flutter_frame_capturer.h"
 #include <stdio.h>
 #include <stdlib.h>
@@ -52,12 +56,7 @@ bool FlutterFrameCapturer::SaveFrame() {
   frame_.get()->ConvertToARGB(RTCVideoFrame::Type::kABGR, pixels,
                               /* unused */ -1, width, height);
 
-  FILE* file;
-#if defined(_WINDOWS)
-  file = fopen_s(path_.c_str(), "wb");
-#else
-  file = fopen(path_.c_str(), "wb");
-#endif
+  FILE* file = fopen(path_.c_str(), "wb");
   if (!file) {
     return false;
   }

--- a/common/cpp/src/flutter_frame_capturer.cc
+++ b/common/cpp/src/flutter_frame_capturer.cc
@@ -1,8 +1,7 @@
 #include "flutter_frame_capturer.h"
 #include <stdio.h>
 #include <stdlib.h>
-
-#include <png.h>
+#include "svpng.hpp"
 
 namespace flutter_webrtc_plugin {
 
@@ -13,20 +12,54 @@ FlutterFrameCapturer::FlutterFrameCapturer(RTCVideoTrack* track,
 }
 
 void FlutterFrameCapturer::OnFrame(scoped_refptr<RTCVideoFrame> frame) {
-  // TODO: convert frame to png and save to path_
+  if (frame_ != nullptr) {
+    return;
+  }
+
+  frame_ = frame.get()->Copy();
   mutex_.unlock();
 }
 
-void FlutterFrameCapturer::Capture(std::unique_ptr<MethodResultProxy> result) {
+void FlutterFrameCapturer::CaptureFrame(
+    std::unique_ptr<MethodResultProxy> result) {
   mutex_.lock();
   track_->AddRenderer(this);
   // Here the OnFrame method has to unlock the mutex
   mutex_.lock();
   track_->RemoveRenderer(this);
+
+  bool success = SaveFrame();
   mutex_.unlock();
 
   std::shared_ptr<MethodResultProxy> result_ptr(result.release());
-  result_ptr->Success();
+  if (success) {
+    result_ptr->Success();
+  } else {
+    result_ptr->Error("1", "Cannot save the frame as .png file");
+  }
+}
+
+bool FlutterFrameCapturer::SaveFrame() {
+  if (frame_ == nullptr) {
+    return false;
+  }
+
+  int width = frame_.get()->width();
+  int height = frame_.get()->height();
+  int bytes_per_pixel = 4;
+  uint8_t* pixels = new uint8_t[width * height * bytes_per_pixel];
+
+  frame_.get()->ConvertToARGB(RTCVideoFrame::Type::kABGR, pixels,
+                              /* unused */ -1, width, height);
+
+  FILE* file = fopen(path_.c_str(), "wb");
+  if (!file) {
+    return false;
+  }
+
+  svpng(file, width, height, pixels, 1);
+  fclose(file);
+  return true;
 }
 
 }  // namespace flutter_webrtc_plugin

--- a/common/cpp/src/flutter_frame_capturer.cc
+++ b/common/cpp/src/flutter_frame_capturer.cc
@@ -52,7 +52,12 @@ bool FlutterFrameCapturer::SaveFrame() {
   frame_.get()->ConvertToARGB(RTCVideoFrame::Type::kABGR, pixels,
                               /* unused */ -1, width, height);
 
-  FILE* file = fopen(path_.c_str(), "wb");
+  FILE* file;
+#if defined(_WINDOWS)
+  file = fopen_s(path_.c_str(), "wb");
+#else
+  file = fopen(path_.c_str(), "wb");
+#endif
   if (!file) {
     return false;
   }

--- a/common/cpp/src/flutter_frame_capturer.cc
+++ b/common/cpp/src/flutter_frame_capturer.cc
@@ -1,0 +1,32 @@
+#include "flutter_frame_capturer.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <png.h>
+
+namespace flutter_webrtc_plugin {
+
+FlutterFrameCapturer::FlutterFrameCapturer(RTCVideoTrack* track,
+                                           std::string path) {
+  track_ = track;
+  path_ = path;
+}
+
+void FlutterFrameCapturer::OnFrame(scoped_refptr<RTCVideoFrame> frame) {
+  // TODO: convert frame to png and save to path_
+  mutex_.unlock();
+}
+
+void FlutterFrameCapturer::Capture(std::unique_ptr<MethodResultProxy> result) {
+  mutex_.lock();
+  track_->AddRenderer(this);
+  // Here the OnFrame method has to unlock the mutex
+  mutex_.lock();
+  track_->RemoveRenderer(this);
+  mutex_.unlock();
+
+  std::shared_ptr<MethodResultProxy> result_ptr(result.release());
+  result_ptr->Success();
+}
+
+}  // namespace flutter_webrtc_plugin

--- a/common/cpp/src/flutter_peerconnection.cc
+++ b/common/cpp/src/flutter_peerconnection.cc
@@ -2,6 +2,7 @@
 
 #include "base/scoped_ref_ptr.h"
 #include "flutter_data_channel.h"
+#include "flutter_frame_capturer.h"
 #include "rtc_dtmf_sender.h"
 #include "rtc_rtp_parameters.h"
 
@@ -107,21 +108,26 @@ EncodableMap rtpParametersToMap(
   }
   info[EncodableValue("codecs")] = EncodableValue(codecs_info);
 
-  switch(rtpParameters->GetDegradationPreference()) {
+  switch (rtpParameters->GetDegradationPreference()) {
     case libwebrtc::RTCDegradationPreference::MAINTAIN_FRAMERATE:
-      info[EncodableValue("degradationPreference")] = EncodableValue("maintain-framerate");
+      info[EncodableValue("degradationPreference")] =
+          EncodableValue("maintain-framerate");
       break;
     case libwebrtc::RTCDegradationPreference::MAINTAIN_RESOLUTION:
-      info[EncodableValue("degradationPreference")] = EncodableValue("maintain-resolution");
+      info[EncodableValue("degradationPreference")] =
+          EncodableValue("maintain-resolution");
       break;
     case libwebrtc::RTCDegradationPreference::BALANCED:
-      info[EncodableValue("degradationPreference")] = EncodableValue("balanced");
+      info[EncodableValue("degradationPreference")] =
+          EncodableValue("balanced");
       break;
     case libwebrtc::RTCDegradationPreference::DISABLED:
-      info[EncodableValue("degradationPreference")] = EncodableValue("disabled");
+      info[EncodableValue("degradationPreference")] =
+          EncodableValue("disabled");
       break;
     default:
-      info[EncodableValue("degradationPreference")] = EncodableValue("balanced"); 
+      info[EncodableValue("degradationPreference")] =
+          EncodableValue("balanced");
       break;
   }
 
@@ -205,7 +211,8 @@ EncodableMap rtpReceiverToMap(
 
 EncodableMap transceiverToMap(scoped_refptr<RTCRtpTransceiver> transceiver) {
   EncodableMap info;
-  info[EncodableValue("transceiverId")] = EncodableValue(transceiver->transceiver_id().std_string());
+  info[EncodableValue("transceiverId")] =
+      EncodableValue(transceiver->transceiver_id().std_string());
   info[EncodableValue("mid")] = EncodableValue(transceiver->mid().std_string());
   info[EncodableValue("direction")] =
       EncodableValue(transceiverDirectionString(transceiver->direction()));
@@ -272,7 +279,6 @@ void FlutterPeerConnection::RTCPeerConnectionClose(
     RTCPeerConnection* pc,
     const std::string& uuid,
     std::unique_ptr<MethodResultProxy> result) {
-
   auto it2 = base_->peerconnections_.find(uuid);
   if (it2 != base_->peerconnections_.end()) {
     it2->second->Close();
@@ -282,7 +288,7 @@ void FlutterPeerConnection::RTCPeerConnectionClose(
   auto it = base_->peerconnection_observers_.find(uuid);
   if (it != base_->peerconnection_observers_.end())
     base_->peerconnection_observers_.erase(it);
-  
+
   result->Success();
 }
 
@@ -643,18 +649,23 @@ scoped_refptr<RTCRtpParameters> FlutterPeerConnection::updateRtpParameters(
       encoding++;
     }
   }
-  
-  EncodableValue value = findEncodableValue(newParameters, "degradationPreference");
-  if(!value.IsNull()) {
+
+  EncodableValue value =
+      findEncodableValue(newParameters, "degradationPreference");
+  if (!value.IsNull()) {
     const std::string degradationPreference = GetValue<std::string>(value);
-    if( degradationPreference == "maintain-framerate") {
-      parameters->SetDegradationPreference(libwebrtc::RTCDegradationPreference::MAINTAIN_FRAMERATE);
-    } else if (degradationPreference  == "maintain-resolution") {
-         parameters->SetDegradationPreference(libwebrtc::RTCDegradationPreference::MAINTAIN_RESOLUTION);
-    } else if(degradationPreference  == "balanced") {
-         parameters->SetDegradationPreference(libwebrtc::RTCDegradationPreference::BALANCED);
-    } else if(degradationPreference  == "disabled") {
-         parameters->SetDegradationPreference(libwebrtc::RTCDegradationPreference::DISABLED);
+    if (degradationPreference == "maintain-framerate") {
+      parameters->SetDegradationPreference(
+          libwebrtc::RTCDegradationPreference::MAINTAIN_FRAMERATE);
+    } else if (degradationPreference == "maintain-resolution") {
+      parameters->SetDegradationPreference(
+          libwebrtc::RTCDegradationPreference::MAINTAIN_RESOLUTION);
+    } else if (degradationPreference == "balanced") {
+      parameters->SetDegradationPreference(
+          libwebrtc::RTCDegradationPreference::BALANCED);
+    } else if (degradationPreference == "disabled") {
+      parameters->SetDegradationPreference(
+          libwebrtc::RTCDegradationPreference::DISABLED);
     }
   }
 
@@ -711,8 +722,8 @@ void FlutterPeerConnection::RtpTransceiverGetCurrentDirection(
     return;
   }
   EncodableMap map;
-  map[EncodableValue("result")] =
-      EncodableValue(transceiverDirectionString(transceiver->current_direction()));
+  map[EncodableValue("result")] = EncodableValue(
+      transceiverDirectionString(transceiver->current_direction()));
   result_ptr->Success(EncodableValue(map));
 }
 
@@ -731,11 +742,8 @@ void FlutterPeerConnection::CaptureFrame(
     RTCVideoTrack* track,
     std::string path,
     std::unique_ptr<MethodResultProxy> result) {
-  std::shared_ptr<MethodResultProxy> result_ptr(result.release());
-
-  // TODO pc->CaptureFrame();
-
-  result_ptr->Success();
+  FlutterFrameCapturer capturer(track, path);
+  capturer.CaptureFrame(std::move(result));
 }
 
 scoped_refptr<RTCRtpTransceiver> FlutterPeerConnection::getRtpTransceiverById(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart'
 import 'package:flutter/material.dart';
 import 'package:flutter_background/flutter_background.dart';
 import 'package:flutter_webrtc/flutter_webrtc.dart';
+import 'package:flutter_webrtc_example/src/capture_frame_sample.dart';
 
 import 'src/device_enumeration_sample.dart';
 import 'src/get_display_media_sample.dart';
@@ -125,6 +126,14 @@ class _MyAppState extends State<MyApp> {
                 MaterialPageRoute(
                     builder: (BuildContext context) =>
                         DataChannelLoopBackSample()));
+          }),
+      RouteItem(
+          title: 'Capture Frame',
+          push: (BuildContext context) {
+            Navigator.push(
+                context,
+                MaterialPageRoute(
+                    builder: (BuildContext context) => CaptureFrameSample()));
           }),
     ];
   }

--- a/example/lib/src/capture_frame_sample.dart
+++ b/example/lib/src/capture_frame_sample.dart
@@ -1,0 +1,57 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_webrtc/flutter_webrtc.dart';
+
+class CaptureFrameSample extends StatefulWidget {
+  @override
+  State<StatefulWidget> createState() => _CaptureFrameSample();
+}
+
+class _CaptureFrameSample extends State<CaptureFrameSample> {
+  Uint8List? _data;
+
+  void _captureFrame() async {
+    final stream = await navigator.mediaDevices.getUserMedia({
+      'audio': false,
+      'video': true,
+    });
+
+    final track = stream.getVideoTracks().first;
+    final buffer = await track.captureFrame();
+
+    stream.getTracks().forEach((track) => track.stop());
+
+    setState(() {
+      _data = buffer.asUint8List();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Capture Frame'),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: _captureFrame,
+        child: Icon(Icons.camera_alt_outlined),
+      ),
+      body: Builder(builder: (context) {
+        final data = _data;
+
+        if (data == null) {
+          return Container();
+        }
+        return Center(
+          child: Image.memory(
+            data,
+            fit: BoxFit.contain,
+            width: double.infinity,
+            height: double.infinity,
+          ),
+        );
+      }),
+    );
+  }
+}

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -35,7 +35,6 @@ include_directories(
   "${CMAKE_CURRENT_SOURCE_DIR}/../third_party/svpng"
 )
 
-
 apply_standard_settings(${PLUGIN_NAME})
 set_target_properties(${PLUGIN_NAME} PROPERTIES
   CXX_VISIBILITY_PRESET hidden)

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -32,7 +32,9 @@ include_directories(
   "${CMAKE_CURRENT_SOURCE_DIR}/../common/cpp/include"
   "${CMAKE_CURRENT_SOURCE_DIR}/../third_party/uuidxx"
   "${CMAKE_CURRENT_SOURCE_DIR}/../third_party/libwebrtc/include"
+  "${CMAKE_CURRENT_SOURCE_DIR}/../third_party/svpng"
 )
+
 
 apply_standard_settings(${PLUGIN_NAME})
 set_target_properties(${PLUGIN_NAME} PROPERTIES

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -14,6 +14,7 @@ add_library(${PLUGIN_NAME} SHARED
   "../common/cpp/src/flutter_frame_cryptor.cc"
   "../common/cpp/src/flutter_media_stream.cc"
   "../common/cpp/src/flutter_peerconnection.cc"
+  "../common/cpp/src/flutter_frame_capturer.cc"
   "../common/cpp/src/flutter_video_renderer.cc"
   "../common/cpp/src/flutter_screen_capture.cc"
   "../common/cpp/src/flutter_webrtc.cc"

--- a/third_party/svpng/LICENSE
+++ b/third_party/svpng/LICENSE
@@ -1,0 +1,26 @@
+Copyright (C) 2017 Milo Yip. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of pngout nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/third_party/svpng/svpng.hpp
+++ b/third_party/svpng/svpng.hpp
@@ -1,0 +1,110 @@
+/*
+Copyright (C) 2017 Milo Yip. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of pngout nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/*! \file
+    \brief      svpng() is a minimalistic C function for saving RGB/RGBA image into uncompressed PNG.
+    \author     Milo Yip
+    \version    0.1.1
+    \copyright  MIT license
+    \sa         http://github.com/miloyip/svpng
+*/
+
+#ifndef SVPNG_INC_
+#define SVPNG_INC_
+
+/*! \def SVPNG_LINKAGE
+    \brief User customizable linkage for svpng() function.
+    By default this macro is empty.
+    User may define this macro as static for static linkage, 
+    and/or inline in C99/C++, etc.
+*/
+#ifndef SVPNG_LINKAGE
+#define SVPNG_LINKAGE
+#endif
+
+/*! \def SVPNG_OUTPUT
+    \brief User customizable output stream.
+    By default, it uses C file descriptor and fputc() to output bytes.
+    In C++, for example, user may use std::ostream or std::vector instead.
+*/
+#ifndef SVPNG_OUTPUT
+#include <stdio.h>
+#define SVPNG_OUTPUT FILE* fp
+#endif
+
+/*! \def SVPNG_PUT
+    \brief Write a byte
+*/
+#ifndef SVPNG_PUT
+#define SVPNG_PUT(u) fputc(u, fp)
+#endif
+
+
+/*!
+    \brief Save a RGB/RGBA image in PNG format.
+    \param SVPNG_OUTPUT Output stream (by default using file descriptor).
+    \param w Width of the image. (<16383)
+    \param h Height of the image.
+    \param img Image pixel data in 24-bit RGB or 32-bit RGBA format.
+    \param alpha Whether the image contains alpha channel.
+*/
+SVPNG_LINKAGE void svpng(SVPNG_OUTPUT, unsigned w, unsigned h, const unsigned char* img, int alpha) {
+    static const unsigned t[] = { 0, 0x1db71064, 0x3b6e20c8, 0x26d930ac, 0x76dc4190, 0x6b6b51f4, 0x4db26158, 0x5005713c, 
+    /* CRC32 Table */    0xedb88320, 0xf00f9344, 0xd6d6a3e8, 0xcb61b38c, 0x9b64c2b0, 0x86d3d2d4, 0xa00ae278, 0xbdbdf21c };
+    unsigned a = 1, b = 0, c, p = w * (alpha ? 4 : 3) + 1, x, y, i;   /* ADLER-a, ADLER-b, CRC, pitch */
+#define SVPNG_U8A(ua, l) for (i = 0; i < l; i++) SVPNG_PUT((ua)[i]);
+#define SVPNG_U32(u) do { SVPNG_PUT((u) >> 24); SVPNG_PUT(((u) >> 16) & 255); SVPNG_PUT(((u) >> 8) & 255); SVPNG_PUT((u) & 255); } while(0)
+#define SVPNG_U8C(u) do { SVPNG_PUT(u); c ^= (u); c = (c >> 4) ^ t[c & 15]; c = (c >> 4) ^ t[c & 15]; } while(0)
+#define SVPNG_U8AC(ua, l) for (i = 0; i < l; i++) SVPNG_U8C((ua)[i])
+#define SVPNG_U16LC(u) do { SVPNG_U8C((u) & 255); SVPNG_U8C(((u) >> 8) & 255); } while(0)
+#define SVPNG_U32C(u) do { SVPNG_U8C((u) >> 24); SVPNG_U8C(((u) >> 16) & 255); SVPNG_U8C(((u) >> 8) & 255); SVPNG_U8C((u) & 255); } while(0)
+#define SVPNG_U8ADLER(u) do { SVPNG_U8C(u); a = (a + (u)) % 65521; b = (b + a) % 65521; } while(0)
+#define SVPNG_BEGIN(s, l) do { SVPNG_U32(l); c = ~0U; SVPNG_U8AC(s, 4); } while(0)
+#define SVPNG_END() SVPNG_U32(~c)
+    SVPNG_U8A("\x89PNG\r\n\32\n", 8);           /* Magic */
+    SVPNG_BEGIN("IHDR", 13);                    /* IHDR chunk { */
+    SVPNG_U32C(w); SVPNG_U32C(h);               /*   Width & Height (8 bytes) */
+    SVPNG_U8C(8); SVPNG_U8C(alpha ? 6 : 2);     /*   Depth=8, Color=True color with/without alpha (2 bytes) */
+    SVPNG_U8AC("\0\0\0", 3);                    /*   Compression=Deflate, Filter=No, Interlace=No (3 bytes) */
+    SVPNG_END();                                /* } */
+    SVPNG_BEGIN("IDAT", 2 + h * (5 + p) + 4);   /* IDAT chunk { */
+    SVPNG_U8AC("\x78\1", 2);                    /*   Deflate block begin (2 bytes) */
+    for (y = 0; y < h; y++) {                   /*   Each horizontal line makes a block for simplicity */
+        SVPNG_U8C(y == h - 1);                  /*   1 for the last block, 0 for others (1 byte) */
+        SVPNG_U16LC(p); SVPNG_U16LC(~p);        /*   Size of block in little endian and its 1's complement (4 bytes) */
+        SVPNG_U8ADLER(0);                       /*   No filter prefix (1 byte) */
+        for (x = 0; x < p - 1; x++, img++)
+            SVPNG_U8ADLER(*img);                /*   Image pixel data */
+    }
+    SVPNG_U32C((b << 16) | a);                  /*   Deflate block end with adler (4 bytes) */
+    SVPNG_END();                                /* } */
+    SVPNG_BEGIN("IEND", 0); SVPNG_END();        /* IEND chunk {} */
+}
+
+#endif /* SVPNG_INC_ */

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -9,6 +9,7 @@ set(PLUGIN_NAME "flutter_webrtc_plugin")
 add_definitions(-DLIB_WEBRTC_API_DLL)
 add_definitions(-DRTC_DESKTOP_DEVICE)
 
+
 add_library(${PLUGIN_NAME} SHARED
   "../common/cpp/flutter_webrtc_plugin.cc"
   "../common/cpp/src/flutter_common.cc"
@@ -26,6 +27,7 @@ add_library(${PLUGIN_NAME} SHARED
 include_directories(
   "${CMAKE_CURRENT_SOURCE_DIR}/../common/cpp/include"
   "${CMAKE_CURRENT_SOURCE_DIR}/../third_party/uuidxx"
+  "${CMAKE_CURRENT_SOURCE_DIR}/../third_party/svpng"
   "${CMAKE_CURRENT_SOURCE_DIR}/../third_party/libwebrtc/include"
 )
 

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -9,7 +9,6 @@ set(PLUGIN_NAME "flutter_webrtc_plugin")
 add_definitions(-DLIB_WEBRTC_API_DLL)
 add_definitions(-DRTC_DESKTOP_DEVICE)
 
-
 add_library(${PLUGIN_NAME} SHARED
   "../common/cpp/flutter_webrtc_plugin.cc"
   "../common/cpp/src/flutter_common.cc"
@@ -17,6 +16,7 @@ add_library(${PLUGIN_NAME} SHARED
   "../common/cpp/src/flutter_frame_cryptor.cc"
   "../common/cpp/src/flutter_media_stream.cc"
   "../common/cpp/src/flutter_peerconnection.cc"
+  "../common/cpp/src/flutter_frame_capturer.cc"
   "../common/cpp/src/flutter_video_renderer.cc"
   "../common/cpp/src/flutter_screen_capture.cc"
   "../common/cpp/src/flutter_webrtc.cc"


### PR DESCRIPTION
add linux desktop support to capture a single frame from `MediaStreamTrack`

- The `FlutterFrameCapturer` class registers as `RTCVideoRenderer` and saves the next frame as file into `/tmp/captureFrame.png`. After success the flutter implementation reads the file and returns its content.
- The file will be saved as PNG through ~~lodepng~~ svpng

Tested on Ubuntu 22.04 aarch64 

See also #838