### PR TITLE
Partially rebuild RTCVideoView when renderVideo value changes

### DIFF
--- a/lib/src/native/rtc_video_view_impl.dart
+++ b/lib/src/native/rtc_video_view_impl.dart
@@ -49,19 +49,19 @@ class RTCVideoView extends StatelessWidget {
                 return SizedBox(
                   width: constraints.maxHeight * value.aspectRatio,
                   height: constraints.maxHeight,
-                  child: child,
+                  child: Transform(
+                    transform: Matrix4.identity()..rotateY(mirror ? -pi : 0.0),
+                    alignment: FractionalOffset.center,
+                    child: value.renderVideo
+                        ? Texture(
+                            textureId: videoRenderer.textureId!,
+                            filterQuality: filterQuality,
+                          )
+                        : child,
+                  ),
                 );
               },
-              child: Transform(
-                transform: Matrix4.identity()..rotateY(mirror ? -pi : 0.0),
-                alignment: FractionalOffset.center,
-                child: videoRenderer.renderVideo
-                    ? Texture(
-                        textureId: videoRenderer.textureId!,
-                        filterQuality: filterQuality,
-                      )
-                    : placeholderBuilder?.call(context) ?? Container(),
-              ),
+              child: placeholderBuilder?.call(context) ?? Container(),
             ),
           ),
         ),


### PR DESCRIPTION
When the `srcObject` value changes (and as a consequence, the `renderVideo` value of `videoRenderer` changes) in a place not related to the widget without a `setState` call (for example within a bloc), the associated `RTCVideoView` widget does not rebuild. As a result, it continues to display a placeholder or Container widget, even if `RTCVideoRenderer.renderVideo` is `true`.

In this pull request, I expand the usage of the `ValueListenableBuilder` widget, which already exists within `RTCVideoView` widget. This allows the actual `renderVideo` value to be respected and triggers a partial rebuild of the `RTCVideoView` widget when the value changes.

By the way in `RTCVideoView` for web this done by [`_onRendererListener`](https://github.com/flutter-webrtc/flutter-webrtc/blob/fad3b57203096516183752e14f4901e893699984/lib/src/web/rtc_video_view_impl.dart#L46) callback that call `setState`.