### PR TITLE
fix: fix android earpiece not being replaced after wired headset is disconnected

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -53,7 +53,7 @@ android {
 
 dependencies {
     implementation 'io.github.webrtc-sdk:android:114.5735.02'
-    implementation 'com.github.davidliu:audioswitch:fb33b237aa50b3d1d2dea0e0695ecb7b38a98971'
+    implementation 'com.github.davidliu:audioswitch:1689af118f69dcd8c8dc95e5a711dd0a7a626e69'
     implementation 'androidx.annotation:annotation:1.1.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }


### PR DESCRIPTION
Original issue: https://github.com/livekit/client-sdk-android/issues/251