### PR TITLE
Fix: [Android] Expose helper to clearCommunicationDevice on AudioManager.AUDIOFOCUS_LOSS

### DIFF
--- a/android/src/main/java/com/cloudwebrtc/webrtc/MethodCallHandlerImpl.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/MethodCallHandlerImpl.java
@@ -538,6 +538,10 @@ public class MethodCallHandlerImpl implements MethodCallHandler, StateProvider {
         result.success(null);
         break;
       }
+      case "clearAndroidCommunicationDevice": {
+        AudioSwitchManager.instance.clearCommunicationDevice();
+        break;
+      }
       case "setMicrophoneMute":
         boolean mute = call.argument("mute");
         AudioSwitchManager.instance.setMicrophoneMute(mute);

--- a/android/src/main/java/com/cloudwebrtc/webrtc/audio/AudioSwitchManager.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/audio/AudioSwitchManager.java
@@ -255,6 +255,9 @@ public class AudioSwitchManager {
             case "gainTransientMayDuck":
                 focusMode = AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK;
                 break;
+            case "loss":
+                focusMode = AudioManager.AUDIOFOCUS_LOSS;
+                break;
             default:
                 Log.w(TAG, "Unknown audio focus mode: " + focusModeString);
                 break;
@@ -267,5 +270,9 @@ public class AudioSwitchManager {
                 Objects.requireNonNull(audioSwitch).setFocusMode(focusMode);
             }
         }
+    }
+
+    public void clearCommunicationDevice() {
+        audioManager.clearCommunicationDevice();
     }
 }

--- a/lib/src/helper.dart
+++ b/lib/src/helper.dart
@@ -129,8 +129,9 @@ class Helper {
       AndroidNativeAudioManagement.setAndroidAudioConfiguration(
           androidAudioConfiguration);
 
-  // After Android app finishes a session, on audio focus loss, clear the active communication device.
-  static Future<void> clearAndroidCommunicationDevice() => WebRTC.invokeMethod('clearAndroidCommunicationDevice');
+  /// After Android app finishes a session, on audio focus loss, clear the active communication device.
+  static Future<void> clearAndroidCommunicationDevice() =>
+      WebRTC.invokeMethod('clearAndroidCommunicationDevice');
 
   /// Set the audio configuration for iOS
   static Future<void> setAppleAudioConfiguration(

--- a/lib/src/helper.dart
+++ b/lib/src/helper.dart
@@ -129,6 +129,9 @@ class Helper {
       AndroidNativeAudioManagement.setAndroidAudioConfiguration(
           androidAudioConfiguration);
 
+  // After Android app finishes a session, on audio focus loss, clear the active communication device.
+  static Future<void> clearAndroidCommunicationDevice() => WebRTC.invokeMethod('clearAndroidCommunicationDevice');
+
   /// Set the audio configuration for iOS
   static Future<void> setAppleAudioConfiguration(
           AppleAudioConfiguration appleAudioConfiguration) =>

--- a/lib/src/native/android/audio_configuration.dart
+++ b/lib/src/native/android/audio_configuration.dart
@@ -24,6 +24,7 @@ enum AndroidAudioFocusMode {
   gainTransient,
   gainTransientExclusive,
   gainTransientMayDuck,
+  loss
 }
 
 extension AndroidAudioFocusModeExt on AndroidAudioFocusMode {


### PR DESCRIPTION
- Expose helper method to clearCommunicationDevice
- Add case: AndroidAudioFocusMode.loss 

Android documentation recommends that when an app finishes a call or session, we should clear the active communication device: https://developer.android.com/guide/topics/connectivity/ble-audio/audio-manager#end_the_session
 
In addition, we should tell the Audio Manager that we want to gain and lose the audio focus:
https://developer.android.com/reference/kotlin/androidx/media/AudioManagerCompat#AUDIOFOCUS_GAIN()

This fix will help to ensure that the user can return to their original audio stream when a webrtc session is finished. 
May resolve https://github.com/flutter-webrtc/flutter-webrtc/issues/351 