### PR TITLE
Added setZoom method to support camera zooming while streaming.

### DIFF
--- a/android/src/main/java/com/cloudwebrtc/webrtc/GetUserMediaImpl.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/GetUserMediaImpl.java
@@ -8,6 +8,7 @@ import android.content.ContentValues;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
+import android.graphics.Rect;
 import android.hardware.Camera;
 import android.hardware.Camera.Parameters;
 import android.hardware.camera2.CameraAccessException;
@@ -111,6 +112,7 @@ class GetUserMediaImpl {
     JavaAudioDeviceModule audioDeviceModule;
     private final SparseArray<MediaRecorderImpl> mediaRecorders = new SparseArray<>();
     private AudioDeviceInfo preferredInput = null;
+    private boolean isTorchOn;
 
     public void screenRequestPermissions(ResultReceiver resultReceiver) {
         final Activity activity = stateProvider.getActivity();
@@ -249,7 +251,7 @@ class GetUserMediaImpl {
     private Map<String, VideoCapturer> createVideoCapturer(
             CameraEnumerator enumerator, boolean isFacing, String sourceId) {
         VideoCapturer videoCapturer = null;
-        Map<String,VideoCapturer> result = new HashMap<String,VideoCapturer>();
+        Map<String, VideoCapturer> result = new HashMap<String, VideoCapturer>();
         // if sourceId given, use specified sourceId first
         final String[] deviceNames = enumerator.getDeviceNames();
         if (sourceId != null && !sourceId.equals("")) {
@@ -258,8 +260,8 @@ class GetUserMediaImpl {
                     videoCapturer = enumerator.createCapturer(name, new CameraEventsHandler());
                     if (videoCapturer != null) {
                         Log.d(TAG, "create user specified camera " + name + " succeeded");
-                       result.put(name,videoCapturer);
-                       return result;
+                        result.put(name, videoCapturer);
+                        return result;
                     } else {
                         Log.d(TAG, "create user specified camera " + name + " failed");
                         break; // fallback to facing mode
@@ -276,7 +278,7 @@ class GetUserMediaImpl {
                 if (videoCapturer != null) {
                     Log.d(TAG, "Create " + facingStr + " camera " + name + " succeeded");
 
-                    result.put(name,videoCapturer);
+                    result.put(name, videoCapturer);
                     return result;
                 } else {
                     Log.e(TAG, "Create " + facingStr + " camera " + name + " failed");
@@ -285,10 +287,10 @@ class GetUserMediaImpl {
         }
 
         // falling back to the first available camera
-        if (videoCapturer == null && deviceNames.length > 0){
+        if (videoCapturer == null && deviceNames.length > 0) {
             videoCapturer = enumerator.createCapturer(deviceNames[0], new CameraEventsHandler());
             Log.d(TAG, "Falling back to the first available camera");
-            result.put(deviceNames[0],videoCapturer);
+            result.put(deviceNames[0], videoCapturer);
         }
 
         return result;
@@ -351,7 +353,7 @@ class GetUserMediaImpl {
         PeerConnectionFactory pcFactory = stateProvider.getPeerConnectionFactory();
         AudioSource audioSource = pcFactory.createAudioSource(audioConstraints);
 
-        if(deviceId != null) {
+        if (deviceId != null) {
             try {
                 setPreferredInputDevice(Integer.parseInt(deviceId));
             } catch (Exception e) {
@@ -359,7 +361,7 @@ class GetUserMediaImpl {
             }
         }
 
-        AudioTrack track =  pcFactory.createAudioTrack(trackId, audioSource);
+        AudioTrack track = pcFactory.createAudioTrack(trackId, audioSource);
         stream.addTrack(track);
 
         stateProvider.putLocalTrack(track.id(), track);
@@ -372,7 +374,7 @@ class GetUserMediaImpl {
         trackParams.putString("readyState", track.state().toString());
         trackParams.putBoolean("remote", false);
 
-        if(deviceId == null) {
+        if (deviceId == null) {
             deviceId = "" + getPreferredInputDevice(preferredInput);
         }
 
@@ -618,7 +620,7 @@ class GetUserMediaImpl {
         ConstraintsMap successResult = new ConstraintsMap();
 
         for (ConstraintsMap trackParam : trackParams) {
-            if(trackParam == null) {
+            if (trackParam == null) {
                 continue;
             }
             if (trackParam.getString("kind").equals("audio")) {
@@ -645,7 +647,7 @@ class GetUserMediaImpl {
      */
     @Nullable
     private Integer getConstrainInt(@Nullable ConstraintsMap constraintsMap, String key) {
-        if(constraintsMap == null){
+        if (constraintsMap == null) {
             return null;
         }
 
@@ -716,7 +718,7 @@ class GetUserMediaImpl {
             return null;
         }
 
-        if(deviceId == null) {
+        if (deviceId == null) {
             deviceId = result.keySet().iterator().next();
         }
 
@@ -736,22 +738,22 @@ class GetUserMediaImpl {
         info.width = videoWidth != null
                 ? videoWidth
                 : videoConstraintsMandatory != null && videoConstraintsMandatory.hasKey("minWidth")
-                        ? videoConstraintsMandatory.getInt("minWidth")
-                        : DEFAULT_WIDTH;
+                ? videoConstraintsMandatory.getInt("minWidth")
+                : DEFAULT_WIDTH;
 
         Integer videoHeight = getConstrainInt(videoConstraintsMap, "height");
         info.height = videoHeight != null
                 ? videoHeight
                 : videoConstraintsMandatory != null && videoConstraintsMandatory.hasKey("minHeight")
-                        ? videoConstraintsMandatory.getInt("minHeight")
-                        : DEFAULT_HEIGHT;
+                ? videoConstraintsMandatory.getInt("minHeight")
+                : DEFAULT_HEIGHT;
 
         Integer videoFrameRate = getConstrainInt(videoConstraintsMap, "frameRate");
         info.fps = videoFrameRate != null
                 ? videoFrameRate
                 : videoConstraintsMandatory != null && videoConstraintsMandatory.hasKey("minFrameRate")
-                        ? videoConstraintsMandatory.getInt("minFrameRate")
-                        : DEFAULT_FPS;
+                ? videoConstraintsMandatory.getInt("minFrameRate")
+                : DEFAULT_FPS;
         info.capturer = videoCapturer;
         videoCapturer.startCapture(info.width, info.height, info.fps);
 
@@ -781,7 +783,7 @@ class GetUserMediaImpl {
         settings.putInt("width", info.width);
         settings.putInt("height", info.height);
         settings.putInt("frameRate", info.fps);
-        if( facingMode!= null) settings.putString("facingMode",facingMode);
+        if (facingMode != null) settings.putString("facingMode", facingMode);
         trackParams.putMap("settings", settings.toMap());
 
         return trackParams;
@@ -799,7 +801,7 @@ class GetUserMediaImpl {
                     info.capturer.dispose();
                     mVideoCapturers.remove(id);
                     SurfaceTextureHelper helper = mSurfaceTextureHelpers.get(id);
-                    if (helper != null)  {
+                    if (helper != null) {
                         helper.stopListening();
                         helper.dispose();
                         mSurfaceTextureHelpers.remove(id);
@@ -883,6 +885,7 @@ class GetUserMediaImpl {
                             @Override
                             public void onCameraSwitchDone(boolean b) {
                                 isFacing = !isFacing;
+                                isTorchOn = false;
                                 result.success(b);
                             }
 
@@ -1006,6 +1009,117 @@ class GetUserMediaImpl {
     }
 
     @RequiresApi(api = VERSION_CODES.LOLLIPOP)
+    void setZoom(String trackId, double zoomLevel, Result result) {
+        VideoCapturerInfo info = mVideoCapturers.get(trackId);
+        if (info == null) {
+            resultError("setZoom", "Video capturer not found for id: " + trackId, result);
+            return;
+        }
+
+        if (info.capturer instanceof Camera2Capturer) {
+            CameraCaptureSession captureSession;
+            CameraDevice cameraDevice;
+            CaptureFormat captureFormat;
+            int fpsUnitFactor;
+            Surface surface;
+            Handler cameraThreadHandler;
+            CameraManager manager;
+
+            try {
+                Object session =
+                        getPrivateProperty(
+                                Camera2Capturer.class.getSuperclass(), info.capturer, "currentSession");
+                manager =
+                        (CameraManager)
+                                getPrivateProperty(Camera2Capturer.class, info.capturer, "cameraManager");
+                captureSession =
+                        (CameraCaptureSession)
+                                getPrivateProperty(session.getClass(), session, "captureSession");
+                cameraDevice =
+                        (CameraDevice) getPrivateProperty(session.getClass(), session, "cameraDevice");
+                captureFormat =
+                        (CaptureFormat) getPrivateProperty(session.getClass(), session, "captureFormat");
+                fpsUnitFactor = (int) getPrivateProperty(session.getClass(), session, "fpsUnitFactor");
+                surface = (Surface) getPrivateProperty(session.getClass(), session, "surface");
+                cameraThreadHandler =
+                        (Handler) getPrivateProperty(session.getClass(), session, "cameraThreadHandler");
+            } catch (NoSuchFieldWithNameException e) {
+                // Most likely the upstream Camera2Capturer class have changed
+                resultError("setZoom", "[ZOOM] Failed to get `" + e.fieldName + "` from `" + e.className + "`", result);
+                return;
+            }
+
+            try {
+                final CaptureRequest.Builder captureRequestBuilder =
+                        cameraDevice.createCaptureRequest(CameraDevice.TEMPLATE_RECORD);
+
+                final CameraCharacteristics cameraCharacteristics = manager.getCameraCharacteristics(cameraDevice.getId());
+                final Rect rect = cameraCharacteristics.get(CameraCharacteristics.SENSOR_INFO_ACTIVE_ARRAY_SIZE);
+                final double maxZoomLevel = cameraCharacteristics.get(CameraCharacteristics.SCALER_AVAILABLE_MAX_DIGITAL_ZOOM);
+
+                final double desiredZoomLevel = Math.max(1.0, Math.min(zoomLevel, maxZoomLevel));
+
+                float ratio = 1.0f / (float)desiredZoomLevel;
+
+                if (rect != null) {
+                    int croppedWidth = rect.width() - Math.round((float) rect.width() * ratio);
+                    int croppedHeight = rect.height() - Math.round((float) rect.height() * ratio);
+                    final Rect desiredRegion = new Rect(croppedWidth / 2, croppedHeight / 2, rect.width() - croppedWidth / 2, rect.height() - croppedHeight / 2);
+                    captureRequestBuilder.set(CaptureRequest.SCALER_CROP_REGION, desiredRegion);
+                }
+
+                captureRequestBuilder.set(
+                        CaptureRequest.FLASH_MODE,
+                        isTorchOn ? CaptureRequest.FLASH_MODE_TORCH : CaptureRequest.FLASH_MODE_OFF);
+                captureRequestBuilder.set(
+                        CaptureRequest.CONTROL_AE_TARGET_FPS_RANGE,
+                        new Range<>(
+                                captureFormat.framerate.min / fpsUnitFactor,
+                                captureFormat.framerate.max / fpsUnitFactor));
+                captureRequestBuilder.set(
+                        CaptureRequest.CONTROL_AE_MODE, CaptureRequest.CONTROL_AE_MODE_ON);
+                captureRequestBuilder.set(CaptureRequest.CONTROL_AE_LOCK, false);
+                captureRequestBuilder.addTarget(surface);
+                captureSession.setRepeatingRequest(
+                        captureRequestBuilder.build(), null, cameraThreadHandler);
+            } catch (CameraAccessException e) {
+                // Should never happen since we are already accessing the camera
+                throw new RuntimeException(e);
+            }
+
+
+            result.success(null);
+            return;
+        }
+
+        if (info.capturer instanceof Camera1Capturer) {
+            Camera camera;
+            try {
+                Object session =
+                        getPrivateProperty(
+                                Camera1Capturer.class.getSuperclass(), info.capturer, "currentSession");
+                camera = (Camera) getPrivateProperty(session.getClass(), session, "camera");
+            } catch (NoSuchFieldWithNameException e) {
+                // Most likely the upstream Camera1Capturer class have changed
+                resultError("setZoom", "[ZOOM] Failed to get `" + e.fieldName + "` from `" + e.className + "`", result);
+                return;
+            }
+
+            Camera.Parameters params = camera.getParameters();
+            params.setFlashMode(
+                    isTorchOn ? Camera.Parameters.FLASH_MODE_TORCH : Camera.Parameters.FLASH_MODE_OFF);
+            if(params.isZoomSupported()) {
+                int maxZoom = params.getMaxZoom();
+                double desiredZoom = Math.max(0, Math.min(zoomLevel, maxZoom));
+                params.setZoom((int)desiredZoom);
+                result.success(null);
+                return;
+            }
+        }
+        resultError("setZoom", "[ZOOM] Video capturer not compatible", result);
+    }
+
+    @RequiresApi(api = VERSION_CODES.LOLLIPOP)
     void setTorch(String trackId, boolean torch, Result result) {
         VideoCapturerInfo info = mVideoCapturers.get(trackId);
         if (info == null) {
@@ -1068,6 +1182,7 @@ class GetUserMediaImpl {
             }
 
             result.success(null);
+            isTorchOn = torch;
             return;
         }
 
@@ -1090,6 +1205,7 @@ class GetUserMediaImpl {
             camera.setParameters(params);
 
             result.success(null);
+            isTorchOn = torch;
             return;
         }
         resultError("setTorch", "[TORCH] Video capturer not compatible", result);
@@ -1157,13 +1273,13 @@ class GetUserMediaImpl {
 
     @RequiresApi(api = VERSION_CODES.M)
     int getPreferredInputDevice(AudioDeviceInfo deviceInfo) {
-        if(deviceInfo == null) {
+        if (deviceInfo == null) {
             return -1;
         }
         android.media.AudioManager audioManager = ((android.media.AudioManager) applicationContext.getSystemService(Context.AUDIO_SERVICE));
         final AudioDeviceInfo[] devices = audioManager.getDevices(android.media.AudioManager.GET_DEVICES_INPUTS);
-        for(int i = 0; i < devices.length; i++) {
-            if(devices[i].getId() == deviceInfo.getId()) {
+        for (int i = 0; i < devices.length; i++) {
+            if (devices[i].getId() == deviceInfo.getId()) {
                 return i;
             }
         }

--- a/android/src/main/java/com/cloudwebrtc/webrtc/MethodCallHandlerImpl.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/MethodCallHandlerImpl.java
@@ -519,6 +519,12 @@ public class MethodCallHandlerImpl implements MethodCallHandler, StateProvider {
         getUserMediaImpl.setTorch(trackId, torch, result);
         break;
       }
+      case "mediaStreamTrackSetZoom": {
+        String trackId = call.argument("trackId");
+        double zoomLevel = call.argument("zoomLevel");
+        getUserMediaImpl.setZoom(trackId, zoomLevel, result);
+        break;
+      }
       case "mediaStreamTrackSwitchCamera": {
         String trackId = call.argument("trackId");
         getUserMediaImpl.switchCamera(trackId, result);

--- a/common/darwin/Classes/FlutterRTCMediaStream.h
+++ b/common/darwin/Classes/FlutterRTCMediaStream.h
@@ -19,6 +19,10 @@
                            torch:(BOOL)torch
                           result:(nonnull FlutterResult)result;
 
+- (void)mediaStreamTrackSetZoom:(nonnull RTCMediaStreamTrack*)track
+                           zoomLevel:(double)zoomLevel
+                          result:(nonnull FlutterResult)result;
+
 - (void)mediaStreamTrackSwitchCamera:(nonnull RTCMediaStreamTrack*)track result:(nonnull FlutterResult)result;
 
 - (void)mediaStreamTrackCaptureFrame:(nonnull RTCMediaStreamTrack*)track

--- a/common/darwin/Classes/FlutterRTCMediaStream.m
+++ b/common/darwin/Classes/FlutterRTCMediaStream.m
@@ -812,6 +812,34 @@ typedef void (^NavigatorUserMediaSuccessCallback)(RTCMediaStream* mediaStream);
   result(nil);
 }
 
+- (void)mediaStreamTrackSetZoom:(RTCMediaStreamTrack*)track
+                           zoomLevel:(double)zoomLevel
+                          result:(FlutterResult)result {
+  if (!self.videoCapturer) {
+    NSLog(@"Video capturer is null. Can't set zoom");
+    return;
+  }
+  if (self.videoCapturer.captureSession.inputs.count == 0) {
+    NSLog(@"Video capturer is missing an input. Can't set zoom");
+    return;
+  }
+
+  AVCaptureDeviceInput* deviceInput = [self.videoCapturer.captureSession.inputs objectAtIndex:0];
+  AVCaptureDevice* device = deviceInput.device;
+
+  NSError* error;
+  if ([device lockForConfiguration:&error] == NO) {
+    NSLog(@"Failed to acquire configuration lock. %@", error.localizedDescription);
+    return;
+  }
+  CGFloat desiredZoomFactor = (CGFloat)zoomLevel;
+  device.videoZoomFactor = MAX(1.0, MIN(desiredZoomFactor, device.activeFormat.videoMaxZoomFactor));
+
+  [device unlockForConfiguration];
+
+  result(nil);
+}
+
 - (void)mediaStreamTrackSwitchCamera:(RTCMediaStreamTrack*)track result:(FlutterResult)result {
   if (!self.videoCapturer) {
     NSLog(@"Video capturer is null. Can't switch camera");

--- a/common/darwin/Classes/FlutterRTCMediaStream.m
+++ b/common/darwin/Classes/FlutterRTCMediaStream.m
@@ -815,6 +815,11 @@ typedef void (^NavigatorUserMediaSuccessCallback)(RTCMediaStream* mediaStream);
 - (void)mediaStreamTrackSetZoom:(RTCMediaStreamTrack*)track
                            zoomLevel:(double)zoomLevel
                           result:(FlutterResult)result {
+#if TARGET_OS_OSX
+  NSLog(@"Not supported on macOS. Can't set zoom");
+  return;
+#endif
+#if TARGET_OS_IPHONE
   if (!self.videoCapturer) {
     NSLog(@"Video capturer is null. Can't set zoom");
     return;
@@ -832,12 +837,13 @@ typedef void (^NavigatorUserMediaSuccessCallback)(RTCMediaStream* mediaStream);
     NSLog(@"Failed to acquire configuration lock. %@", error.localizedDescription);
     return;
   }
+  
   CGFloat desiredZoomFactor = (CGFloat)zoomLevel;
   device.videoZoomFactor = MAX(1.0, MIN(desiredZoomFactor, device.activeFormat.videoMaxZoomFactor));
-
   [device unlockForConfiguration];
 
   result(nil);
+#endif
 }
 
 - (void)mediaStreamTrackSwitchCamera:(RTCMediaStreamTrack*)track result:(FlutterResult)result {

--- a/common/darwin/Classes/FlutterWebRTCPlugin.m
+++ b/common/darwin/Classes/FlutterWebRTCPlugin.m
@@ -781,6 +781,24 @@ NSArray<RTC_OBJC_TYPE(RTCVideoCodecInfo) *>* motifyH264ProfileLevelId(
                                    details:nil]);
       }
     }
+  } else if ([@"mediaStreamTrackSetZoom" isEqualToString:call.method]) {
+    NSDictionary* argsMap = call.arguments;
+    NSString* trackId = argsMap[@"trackId"];
+    double zoomLevel = [argsMap[@"zoomLevel"] doubleValue];
+    RTCMediaStreamTrack* track = self.localTracks[trackId];
+    if (track != nil && [track isKindOfClass:[RTCVideoTrack class]]) {
+      RTCVideoTrack* videoTrack = (RTCVideoTrack*)track;
+      [self mediaStreamTrackSetZoom:videoTrack zoomLevel:zoomLevel result:result];
+    } else {
+      if (track == nil) {
+        result([FlutterError errorWithCode:@"Track is nil" message:nil details:nil]);
+      } else {
+        result([FlutterError errorWithCode:[@"Track is class of "
+                                               stringByAppendingString:[[track class] description]]
+                                   message:nil
+                                   details:nil]);
+      }
+    }
   } else if ([@"mediaStreamTrackSwitchCamera" isEqualToString:call.method]) {
     NSDictionary* argsMap = call.arguments;
     NSString* trackId = argsMap[@"trackId"];

--- a/example/lib/src/get_user_media_sample.dart
+++ b/example/lib/src/get_user_media_sample.dart
@@ -22,6 +22,7 @@ class _GetUserMediaSampleState extends State<GetUserMediaSample> {
   bool _inCalling = false;
   bool _isTorchOn = false;
   MediaRecorder? _mediaRecorder;
+
   bool get _isRec => _mediaRecorder != null;
 
   List<MediaDeviceInfo>? _mediaDevicesList;
@@ -143,6 +144,18 @@ class _GetUserMediaSampleState extends State<GetUserMediaSample> {
     }
   }
 
+  void setZoom(double zoomLevel) async {
+    if (_localStream == null) throw Exception('Stream is not initialized');
+    // await videoTrack.setZoom(zoomLevel); //Use it after published webrtc_interface 1.1.1
+
+    // before the release, use can just call native method directly.
+    final videoTrack = _localStream!
+        .getVideoTracks()
+        .firstWhere((track) => track.kind == 'video');
+    await WebRTC.invokeMethod('mediaStreamTrackSetZoom',
+        <String, dynamic>{'trackId': videoTrack.id, 'zoomLevel': zoomLevel});
+  }
+
   void _toggleCamera() async {
     if (_localStream == null) throw Exception('Stream is not initialized');
 
@@ -218,14 +231,21 @@ class _GetUserMediaSampleState extends State<GetUserMediaSample> {
       body: OrientationBuilder(
         builder: (context, orientation) {
           return Center(
-            child: Container(
-              margin: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 0.0),
-              width: MediaQuery.of(context).size.width,
-              height: MediaQuery.of(context).size.height,
-              decoration: BoxDecoration(color: Colors.black54),
+              child: Container(
+            margin: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 0.0),
+            width: MediaQuery.of(context).size.width,
+            height: MediaQuery.of(context).size.height,
+            decoration: BoxDecoration(color: Colors.black54),
+            child: GestureDetector(
+              onScaleStart: (details) {},
+              onScaleUpdate: (details) {
+                if (details.scale != 1.0) {
+                  setZoom(details.scale);
+                }
+              },
               child: RTCVideoView(_localRenderer, mirror: true),
             ),
-          );
+          ));
         },
       ),
       floatingActionButton: FloatingActionButton(

--- a/lib/src/helper.dart
+++ b/lib/src/helper.dart
@@ -67,6 +67,18 @@ class Helper {
     return Future.value(true);
   }
 
+  static Future<void> setZoom(
+      MediaStreamTrack videoTrack, double zoomLevel) async {
+    if (WebRTC.platformIsAndroid || WebRTC.platformIsIOS) {
+      await WebRTC.invokeMethod(
+        'mediaStreamTrackSetZoom',
+        <String, dynamic>{'trackId': videoTrack.id, 'zoomLevel': zoomLevel},
+      );
+    } else {
+      throw Exception('setZoom only support for mobile devices!');
+    }
+  }
+
   /// Used to select a specific audio output device.
   ///
   /// Note: This method is only used for Flutter native,

--- a/lib/src/native/media_stream_track_impl.dart
+++ b/lib/src/native/media_stream_track_impl.dart
@@ -73,6 +73,12 @@ class MediaStreamTrackNative extends MediaStreamTrack {
       );
 
   @override
+  Future<void> setZoom(double zoomLevel) => WebRTC.invokeMethod(
+    'mediaStreamTrackSetZoom',
+    <String, dynamic>{'trackId': _trackId, 'zoomLevel': zoomLevel},
+  );
+
+  @override
   Future<bool> switchCamera() => Helper.switchCamera(this);
 
   @Deprecated('Use Helper.setSpeakerphoneOn instead')

--- a/lib/src/native/media_stream_track_impl.dart
+++ b/lib/src/native/media_stream_track_impl.dart
@@ -74,9 +74,9 @@ class MediaStreamTrackNative extends MediaStreamTrack {
 
   @override
   Future<void> setZoom(double zoomLevel) => WebRTC.invokeMethod(
-    'mediaStreamTrackSetZoom',
-    <String, dynamic>{'trackId': _trackId, 'zoomLevel': zoomLevel},
-  );
+        'mediaStreamTrackSetZoom',
+        <String, dynamic>{'trackId': _trackId, 'zoomLevel': zoomLevel},
+      );
 
   @override
   Future<bool> switchCamera() => Helper.switchCamera(this);

--- a/lib/src/native/media_stream_track_impl.dart
+++ b/lib/src/native/media_stream_track_impl.dart
@@ -72,14 +72,10 @@ class MediaStreamTrackNative extends MediaStreamTrack {
         <String, dynamic>{'trackId': _trackId, 'torch': torch},
       );
 
-//  @override
-  Future<void> setZoom(double zoomLevel) => WebRTC.invokeMethod(
-        'mediaStreamTrackSetZoom',
-        <String, dynamic>{'trackId': _trackId, 'zoomLevel': zoomLevel},
-      );
-
   @override
   Future<bool> switchCamera() => Helper.switchCamera(this);
+
+  Future<void> setZoom(double zoomLevel) => Helper.setZoom(this, zoomLevel);
 
   @Deprecated('Use Helper.setSpeakerphoneOn instead')
   @override

--- a/lib/src/native/media_stream_track_impl.dart
+++ b/lib/src/native/media_stream_track_impl.dart
@@ -72,7 +72,7 @@ class MediaStreamTrackNative extends MediaStreamTrack {
         <String, dynamic>{'trackId': _trackId, 'torch': torch},
       );
 
-  @override
+//  @override
   Future<void> setZoom(double zoomLevel) => WebRTC.invokeMethod(
         'mediaStreamTrackSetZoom',
         <String, dynamic>{'trackId': _trackId, 'zoomLevel': zoomLevel},


### PR DESCRIPTION
iOS and AOS support (tested on iOS and AOS mobile devices)

How to use?

final videoTrack = _localStream!
        .getVideoTracks()
        .firstWhere((track) => track.kind == 'video');
    await WebRTC.invokeMethod('mediaStreamTrackSetZoom',
        <String, dynamic>{'trackId': videoTrack.id, 'zoomLevel': zoomLevel});
        
        
//After [this PR](https://github.com/flutter-webrtc/webrtc-interface/pull/20) is published. 
(webrtc_interface version needs to be updated  in pubspec.yaml)

await videoTrack.setZoom(zoomLevel); 