### PR TITLE
Check the invalid value of candidate and session description.

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -41,10 +41,6 @@ analyzer:
     # allow self-reference to deprecated members (we do this because otherwise we have
     # to annotate every member in every test, assert, etc, when we deprecate something)
     deprecated_member_use_from_same_package: ignore
-    # Ignore analyzer hints for updating pubspecs when using Future or
-    # Stream and not importing dart:async
-    # Please see https://github.com/flutter/flutter/pull/24528 for details.
-    sdk_version_async_exported_from_core: ignore
     # Conflict with import_sorter
     directives_ordering: ignore
     constant_identifier_names: ignore

--- a/common/cpp/src/flutter_webrtc.cc
+++ b/common/cpp/src/flutter_webrtc.cc
@@ -276,7 +276,7 @@ void FlutterWebRTC::HandleMethodCall(
     SdpParseError error;
     std::string candidate = findString(constraints, "candidate");
     if (candidate.empty()) {
-      LOG_DEBUG("addCandidate, add end-of-candidates");
+      // received the end-of-candidates
       result->Success();
       return;
     }

--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -40,7 +40,3 @@ analyzer:
     # allow self-reference to deprecated members (we do this because otherwise we have
     # to annotate every member in every test, assert, etc, when we deprecate something)
     deprecated_member_use_from_same_package: ignore
-    # Ignore analyzer hints for updating pubspecs when using Future or
-    # Stream and not importing dart:async
-    # Please see https://github.com/flutter/flutter/pull/24528 for details.
-    sdk_version_async_exported_from_core: ignore


### PR DESCRIPTION
  * libwebrtc should been updated, the crash issue has been fixed because of invalid candidate or session description.
  * Empty candidate means all candidates have been received, it's a valid value.
  * Add null check for candidate or session description.