### PR TITLE
Fix: platformViewRegistry getter is deprecated

### DIFF
--- a/lib/src/web/rtc_video_renderer_impl.dart
+++ b/lib/src/web/rtc_video_renderer_impl.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 import 'dart:html' as html;
 import 'dart:js_util' as jsutil;
-import 'dart:ui' as ui;
+import 'dart:ui_web' as ui;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';


### PR DESCRIPTION
The platformViewRegistry getter is deprecated and will be removed in a future release. Please import it from `dart:ui_web` instead.
<img width="531" alt="Screenshot 2023-11-19 at 6 17 02 PM" src="https://github.com/flutter-webrtc/flutter-webrtc/assets/8187501/da9218a1-9d57-41bc-acb9-f1445726552c">
