### PR TITLE
fix android wrong screen capture size.

### DIFF
--- a/android/src/main/java/com/cloudwebrtc/webrtc/GetUserMediaImpl.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/GetUserMediaImpl.java
@@ -8,6 +8,7 @@ import android.content.ContentValues;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
+import android.graphics.Point;
 import android.graphics.Rect;
 import android.hardware.Camera;
 import android.hardware.Camera.Parameters;
@@ -28,9 +29,11 @@ import android.os.Handler;
 import android.os.Looper;
 import android.os.ResultReceiver;
 import android.provider.MediaStore;
+import android.util.DisplayMetrics;
 import android.util.Log;
 import android.util.Range;
 import android.util.SparseArray;
+import android.view.Display;
 import android.view.Surface;
 import android.view.WindowManager;
 
@@ -517,9 +520,13 @@ class GetUserMediaImpl {
                         WindowManager wm =
                                 (WindowManager) applicationContext.getSystemService(Context.WINDOW_SERVICE);
 
+                        Display display = wm.getDefaultDisplay();
+                        Point size = new Point();
+                        display.getRealSize(size);
+
                         VideoCapturerInfo info = new VideoCapturerInfo();
-                        info.width = wm.getDefaultDisplay().getWidth();
-                        info.height = wm.getDefaultDisplay().getHeight();
+                        info.width= size.x;
+                        info.height = size.y;
                         info.fps = DEFAULT_FPS;
                         info.isScreenCapture = true;
                         info.capturer = videoCapturer;


### PR DESCRIPTION
When you use the android screen capture feature, it provides an incorrect capture size; in most cases, this bug may not be a significant issue. However, it becomes problematic when working with the Flutter overlay view. (iOS works okay.)

The log is shown below.
2023-12-27 14:56:27.549 14766-14766 FlutterWebRTCPlugin D OrientationAwareScreenCapturer.startCapture: 1080x2122@30
Test Device: Galaxy S20 Ultra 5G
Device screen size: 1080x2316