### PR TITLE
support media projection feature for android 14

### DIFF
--- a/android/src/main/java/com/cloudwebrtc/webrtc/GetUserMediaImpl.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/GetUserMediaImpl.java
@@ -115,8 +115,10 @@ class GetUserMediaImpl {
     private final SparseArray<MediaRecorderImpl> mediaRecorders = new SparseArray<>();
     private AudioDeviceInfo preferredInput = null;
     private boolean isTorchOn;
+    private Intent mediaProjectionData = null;
 
     public void screenRequestPermissions(ResultReceiver resultReceiver) {
+        mediaProjectionData = null;
         final Activity activity = stateProvider.getActivity();
         if (activity == null) {
             // Activity went away, nothing we can do.
@@ -141,6 +143,22 @@ class GetUserMediaImpl {
         } catch (IllegalStateException ise) {
 
         }
+    }
+
+    public void requestCapturePermission(final Result result) {
+        screenRequestPermissions(
+                new ResultReceiver(new Handler(Looper.getMainLooper())) {
+                    @Override
+                    protected void onReceiveResult(int requestCode, Bundle resultData) {
+                        int resultCode = resultData.getInt(GRANT_RESULTS);
+                        if (resultCode == Activity.RESULT_OK) {
+                            mediaProjectionData = resultData.getParcelable(PROJECTION_DATA);
+                            result.success(true);
+                        } else {
+                            result.success(false);
+                        }
+                    }
+                });
     }
 
     public static class ScreenRequestPermissionsFragment extends Fragment {
@@ -474,116 +492,121 @@ class GetUserMediaImpl {
 
     void getDisplayMedia(
             final ConstraintsMap constraints, final Result result, final MediaStream mediaStream) {
+        if (mediaProjectionData == null) {
+            screenRequestPermissions(
+                    new ResultReceiver(new Handler(Looper.getMainLooper())) {
+                        @Override
+                        protected void onReceiveResult(int requestCode, Bundle resultData) {
+                            Intent mediaProjectionData = resultData.getParcelable(PROJECTION_DATA);
+                            int resultCode = resultData.getInt(GRANT_RESULTS);
 
-        screenRequestPermissions(
-                new ResultReceiver(new Handler(Looper.getMainLooper())) {
-                    @Override
-                    protected void onReceiveResult(int requestCode, Bundle resultData) {
-
-                        /* Create ScreenCapture */
-                        int resultCode = resultData.getInt(GRANT_RESULTS);
-                        Intent mediaProjectionData = resultData.getParcelable(PROJECTION_DATA);
-
-                        if (resultCode != Activity.RESULT_OK) {
-                            resultError("screenRequestPermissions", "User didn't give permission to capture the screen.", result);
-                            return;
-                        }
-
-                        MediaStreamTrack[] tracks = new MediaStreamTrack[1];
-                        VideoCapturer videoCapturer = null;
-                        videoCapturer =
-                                new OrientationAwareScreenCapturer(
-                                        mediaProjectionData,
-                                        new MediaProjection.Callback() {
-                                            @Override
-                                            public void onStop() {
-                                                super.onStop();
-                                                // After Huawei P30 and Android 10 version test, the onstop method is called, which will not affect the next process, 
-                                                // and there is no need to call the resulterror method
-                                                //resultError("MediaProjection.Callback()", "User revoked permission to capture the screen.", result);
-                                            }
-                                        });
-                        if (videoCapturer == null) {
-                            resultError("screenRequestPermissions", "GetDisplayMediaFailed, User revoked permission to capture the screen.", result);
-                            return;
-                        }
-
-                        PeerConnectionFactory pcFactory = stateProvider.getPeerConnectionFactory();
-                        VideoSource videoSource = pcFactory.createVideoSource(true);
-
-                        String threadName = Thread.currentThread().getName() + "_texture_screen_thread";
-                        SurfaceTextureHelper surfaceTextureHelper =
-                                SurfaceTextureHelper.create(threadName, EglUtils.getRootEglBaseContext());
-                        videoCapturer.initialize(
-                                surfaceTextureHelper, applicationContext, videoSource.getCapturerObserver());
-
-                        WindowManager wm =
-                                (WindowManager) applicationContext.getSystemService(Context.WINDOW_SERVICE);
-
-                        Display display = wm.getDefaultDisplay();
-                        Point size = new Point();
-                        display.getRealSize(size);
-
-                        VideoCapturerInfo info = new VideoCapturerInfo();
-                        info.width= size.x;
-                        info.height = size.y;
-                        info.fps = DEFAULT_FPS;
-                        info.isScreenCapture = true;
-                        info.capturer = videoCapturer;
-
-                        videoCapturer.startCapture(info.width, info.height, info.fps);
-                        Log.d(TAG, "OrientationAwareScreenCapturer.startCapture: " + info.width + "x" + info.height + "@" + info.fps);
-
-                        String trackId = stateProvider.getNextTrackUUID();
-                        mVideoCapturers.put(trackId, info);
-
-                        tracks[0] = pcFactory.createVideoTrack(trackId, videoSource);
-
-                        ConstraintsArray audioTracks = new ConstraintsArray();
-                        ConstraintsArray videoTracks = new ConstraintsArray();
-                        ConstraintsMap successResult = new ConstraintsMap();
-
-                        for (MediaStreamTrack track : tracks) {
-                            if (track == null) {
-                                continue;
+                            if (resultCode != Activity.RESULT_OK) {
+                                resultError("screenRequestPermissions", "User didn't give permission to capture the screen.", result);
+                                return;
                             }
-
-                            String id = track.id();
-
-                            if (track instanceof AudioTrack) {
-                                mediaStream.addTrack((AudioTrack) track);
-                            } else {
-                                mediaStream.addTrack((VideoTrack) track);
-                            }
-                            stateProvider.putLocalTrack(id, track);
-
-                            ConstraintsMap track_ = new ConstraintsMap();
-                            String kind = track.kind();
-
-                            track_.putBoolean("enabled", track.enabled());
-                            track_.putString("id", id);
-                            track_.putString("kind", kind);
-                            track_.putString("label", kind);
-                            track_.putString("readyState", track.state().toString());
-                            track_.putBoolean("remote", false);
-
-                            if (track instanceof AudioTrack) {
-                                audioTracks.pushMap(track_);
-                            } else {
-                                videoTracks.pushMap(track_);
-                            }
+                            getDisplayMedia(result, mediaStream, mediaProjectionData);
                         }
+                    });
+        } else {
+            getDisplayMedia(result, mediaStream, mediaProjectionData);
+        }
+    }
 
-                        String streamId = mediaStream.getId();
+    private void getDisplayMedia(final Result result, final MediaStream mediaStream, final Intent mediaProjectionData) {
+        /* Create ScreenCapture */
+        MediaStreamTrack[] tracks = new MediaStreamTrack[1];
+        VideoCapturer videoCapturer = null;
+        videoCapturer =
+                new OrientationAwareScreenCapturer(
+                        mediaProjectionData,
+                        new MediaProjection.Callback() {
+                            @Override
+                            public void onStop() {
+                                super.onStop();
+                                // After Huawei P30 and Android 10 version test, the onstop method is called, which will not affect the next process,
+                                // and there is no need to call the resulterror method
+                                //resultError("MediaProjection.Callback()", "User revoked permission to capture the screen.", result);
+                            }
+                        });
+        if (videoCapturer == null) {
+            resultError("screenRequestPermissions", "GetDisplayMediaFailed, User revoked permission to capture the screen.", result);
+            return;
+        }
 
-                        Log.d(TAG, "MediaStream id: " + streamId);
-                        stateProvider.putLocalStream(streamId, mediaStream);
-                        successResult.putString("streamId", streamId);
-                        successResult.putArray("audioTracks", audioTracks.toArrayList());
-                        successResult.putArray("videoTracks", videoTracks.toArrayList());
-                        result.success(successResult.toMap());
-                    }
-                });
+        PeerConnectionFactory pcFactory = stateProvider.getPeerConnectionFactory();
+        VideoSource videoSource = pcFactory.createVideoSource(true);
+
+        String threadName = Thread.currentThread().getName() + "_texture_screen_thread";
+        SurfaceTextureHelper surfaceTextureHelper =
+                SurfaceTextureHelper.create(threadName, EglUtils.getRootEglBaseContext());
+        videoCapturer.initialize(
+                surfaceTextureHelper, applicationContext, videoSource.getCapturerObserver());
+
+        WindowManager wm =
+                (WindowManager) applicationContext.getSystemService(Context.WINDOW_SERVICE);
+
+        Display display = wm.getDefaultDisplay();
+        Point size = new Point();
+        display.getRealSize(size);
+
+        VideoCapturerInfo info = new VideoCapturerInfo();
+        info.width = size.x;
+        info.height = size.y;
+        info.fps = DEFAULT_FPS;
+        info.isScreenCapture = true;
+        info.capturer = videoCapturer;
+
+        videoCapturer.startCapture(info.width, info.height, info.fps);
+        Log.d(TAG, "OrientationAwareScreenCapturer.startCapture: " + info.width + "x" + info.height + "@" + info.fps);
+
+        String trackId = stateProvider.getNextTrackUUID();
+        mVideoCapturers.put(trackId, info);
+
+        tracks[0] = pcFactory.createVideoTrack(trackId, videoSource);
+
+        ConstraintsArray audioTracks = new ConstraintsArray();
+        ConstraintsArray videoTracks = new ConstraintsArray();
+        ConstraintsMap successResult = new ConstraintsMap();
+
+        for (MediaStreamTrack track : tracks) {
+            if (track == null) {
+                continue;
+            }
+
+            String id = track.id();
+
+            if (track instanceof AudioTrack) {
+                mediaStream.addTrack((AudioTrack) track);
+            } else {
+                mediaStream.addTrack((VideoTrack) track);
+            }
+            stateProvider.putLocalTrack(id, track);
+
+            ConstraintsMap track_ = new ConstraintsMap();
+            String kind = track.kind();
+
+            track_.putBoolean("enabled", track.enabled());
+            track_.putString("id", id);
+            track_.putString("kind", kind);
+            track_.putString("label", kind);
+            track_.putString("readyState", track.state().toString());
+            track_.putBoolean("remote", false);
+
+            if (track instanceof AudioTrack) {
+                audioTracks.pushMap(track_);
+            } else {
+                videoTracks.pushMap(track_);
+            }
+        }
+
+        String streamId = mediaStream.getId();
+
+        Log.d(TAG, "MediaStream id: " + streamId);
+        stateProvider.putLocalStream(streamId, mediaStream);
+        successResult.putString("streamId", streamId);
+        successResult.putArray("audioTracks", audioTracks.toArrayList());
+        successResult.putArray("videoTracks", videoTracks.toArrayList());
+        result.success(successResult.toMap());
     }
 
     /**

--- a/android/src/main/java/com/cloudwebrtc/webrtc/MethodCallHandlerImpl.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/MethodCallHandlerImpl.java
@@ -624,6 +624,10 @@ public class MethodCallHandlerImpl implements MethodCallHandler, StateProvider {
         AudioSwitchManager.instance.enableSpeakerButPreferBluetooth();
         result.success(null);
         break;
+      case "requestCapturePermission": {
+        getUserMediaImpl.requestCapturePermission(result);
+        break;
+      }
       case "getDisplayMedia": {
         Map<String, Object> constraints = call.argument("constraints");
         ConstraintsMap constraintsMap = new ConstraintsMap(constraints);

--- a/android/src/main/java/com/cloudwebrtc/webrtc/OrientationAwareScreenCapturer.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/OrientationAwareScreenCapturer.java
@@ -1,29 +1,44 @@
 package com.cloudwebrtc.webrtc;
 
-import org.webrtc.ScreenCapturerAndroid;
 import org.webrtc.SurfaceTextureHelper;
 import org.webrtc.CapturerObserver;
+import org.webrtc.ThreadUtils;
+import org.webrtc.VideoCapturer;
 import org.webrtc.VideoFrame;
+import org.webrtc.VideoSink;
 
 import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.Intent;
 import android.media.projection.MediaProjection;
-import android.util.Log;
 import android.view.Surface;
 import android.view.WindowManager;
-
+import android.app.Activity;
+import android.hardware.display.DisplayManager;
+import android.hardware.display.VirtualDisplay;
+import android.media.projection.MediaProjectionManager;
 
 /**
- * An implementation of ScreenCapturerAndroid to capture the screen content while being aware of device orientation
+ * An copy of ScreenCapturerAndroid to capture the screen content while being aware of device orientation
  */
 @TargetApi(21)
-public class OrientationAwareScreenCapturer
-        extends ScreenCapturerAndroid {
-    private Context applicationContext;
-    private WindowManager windowManager;
+public class OrientationAwareScreenCapturer implements VideoCapturer, VideoSink {
+    private static final int DISPLAY_FLAGS =
+            DisplayManager.VIRTUAL_DISPLAY_FLAG_PUBLIC | DisplayManager.VIRTUAL_DISPLAY_FLAG_PRESENTATION;
+    // DPI for VirtualDisplay, does not seem to matter for us.
+    private static final int VIRTUAL_DISPLAY_DPI = 400;
+    private final Intent mediaProjectionPermissionResultData;
+    private final MediaProjection.Callback mediaProjectionCallback;
     private int width;
     private int height;
+    private VirtualDisplay virtualDisplay;
+    private SurfaceTextureHelper surfaceTextureHelper;
+    private CapturerObserver capturerObserver;
+    private long numCapturedFrames = 0;
+    private MediaProjection mediaProjection;
+    private boolean isDisposed = false;
+    private MediaProjectionManager mediaProjectionManager;
+    private WindowManager windowManager;
     private boolean isPortrait;
 
     /**
@@ -37,44 +52,23 @@ public class OrientationAwareScreenCapturer
      **/
     public OrientationAwareScreenCapturer(Intent mediaProjectionPermissionResultData,
                                           MediaProjection.Callback mediaProjectionCallback) {
-        super(mediaProjectionPermissionResultData, mediaProjectionCallback);
+        this.mediaProjectionPermissionResultData = mediaProjectionPermissionResultData;
+        this.mediaProjectionCallback = mediaProjectionCallback;
     }
 
-    @Override
-    public synchronized void initialize(SurfaceTextureHelper surfaceTextureHelper, Context applicationContext, CapturerObserver capturerObserver) {
-        super.initialize(surfaceTextureHelper, applicationContext, capturerObserver);
-        this.applicationContext = applicationContext;
-        Log.d("OrientationAwareSC", "OrientationAwareScreenCapturer: initialized and orientation isPortrait? " + this.isPortrait);
-    }
-
-    @Override
-    public synchronized void startCapture(int width, int height, int ignoredFramerate) {
-        this.windowManager = (WindowManager) applicationContext.getSystemService(
-                Context.WINDOW_SERVICE);
-        this.isPortrait = isDeviceOrientationPortrait();
-        if (this.isPortrait) {
-            this.width = width;
-            this.height = height;
-        } else {
-            this.height = width;
-            this.width = height;
-        }
-        super.startCapture(width, height, ignoredFramerate);
-    }
-
-    @Override
     public void onFrame(VideoFrame frame) {
+        checkNotDisposed();
         final boolean isOrientationPortrait = isDeviceOrientationPortrait();
         if (isOrientationPortrait != this.isPortrait) {
             this.isPortrait = isOrientationPortrait;
 
             if (this.isPortrait) {
-                super.changeCaptureFormat(this.width, this.height, 15);
+                changeCaptureFormat(this.width, this.height, 15);
             } else {
-                super.changeCaptureFormat(this.height, this.width, 15);
+                changeCaptureFormat(this.height, this.width, 15);
             }
         }
-        super.onFrame(frame);
+        capturerObserver.onFrameCaptured(frame);
     }
 
     private boolean isDeviceOrientationPortrait() {
@@ -83,4 +77,120 @@ public class OrientationAwareScreenCapturer
         return surfaceRotation != Surface.ROTATION_90 && surfaceRotation != Surface.ROTATION_270;
     }
 
+
+    private void checkNotDisposed() {
+        if (isDisposed) {
+            throw new RuntimeException("capturer is disposed.");
+        }
+    }
+    public synchronized void initialize(final SurfaceTextureHelper surfaceTextureHelper,
+                                        final Context applicationContext, final CapturerObserver capturerObserver) {
+        checkNotDisposed();
+        if (capturerObserver == null) {
+            throw new RuntimeException("capturerObserver not set.");
+        }
+        this.capturerObserver = capturerObserver;
+        if (surfaceTextureHelper == null) {
+            throw new RuntimeException("surfaceTextureHelper not set.");
+        }
+        this.surfaceTextureHelper = surfaceTextureHelper;
+
+        this.windowManager = (WindowManager) applicationContext.getSystemService(
+                Context.WINDOW_SERVICE);
+        this.mediaProjectionManager = (MediaProjectionManager) applicationContext.getSystemService(
+                Context.MEDIA_PROJECTION_SERVICE);
+    }
+    @Override
+    public synchronized void startCapture(
+            final int width, final int height, final int ignoredFramerate) {
+        //checkNotDisposed();
+
+        this.isPortrait = isDeviceOrientationPortrait();
+        if (this.isPortrait) {
+            this.width = width;
+            this.height = height;
+        } else {
+            this.height = width;
+            this.width = height;
+        }
+
+        mediaProjection = mediaProjectionManager.getMediaProjection(
+                Activity.RESULT_OK, mediaProjectionPermissionResultData);
+
+        // Let MediaProjection callback use the SurfaceTextureHelper thread.
+        mediaProjection.registerCallback(mediaProjectionCallback, surfaceTextureHelper.getHandler());
+
+        createVirtualDisplay();
+        capturerObserver.onCapturerStarted(true);
+        surfaceTextureHelper.startListening(this);
+    }
+    @Override
+    public synchronized void stopCapture() {
+        checkNotDisposed();
+        ThreadUtils.invokeAtFrontUninterruptibly(surfaceTextureHelper.getHandler(), new Runnable() {
+            @Override
+            public void run() {
+                surfaceTextureHelper.stopListening();
+                capturerObserver.onCapturerStopped();
+                if (virtualDisplay != null) {
+                    virtualDisplay.release();
+                    virtualDisplay = null;
+                }
+                if (mediaProjection != null) {
+                    // Unregister the callback before stopping, otherwise the callback recursively
+                    // calls this method.
+                    mediaProjection.unregisterCallback(mediaProjectionCallback);
+                    mediaProjection.stop();
+                    mediaProjection = null;
+                }
+            }
+        });
+    }
+    @Override
+    public synchronized void dispose() {
+        isDisposed = true;
+    }
+    /**
+     * Changes output video format. This method can be used to scale the output
+     * video, or to change orientation when the captured screen is rotated for example.
+     *
+     * @param width new output video width
+     * @param height new output video height
+     * @param ignoredFramerate ignored
+     */
+    @Override
+    public synchronized void changeCaptureFormat(
+            final int width, final int height, final int ignoredFramerate) {
+        checkNotDisposed();
+        this.width = width;
+        this.height = height;
+        if (virtualDisplay == null) {
+            // Capturer is stopped, the virtual display will be created in startCaptuer().
+            return;
+        }
+
+        ThreadUtils.invokeAtFrontUninterruptibly(surfaceTextureHelper.getHandler(), new Runnable() {
+            @Override
+            public void run() {
+                surfaceTextureHelper.setTextureSize(width, height);
+                virtualDisplay.resize(width, height, VIRTUAL_DISPLAY_DPI);
+            }
+        });
+    }
+    private void createVirtualDisplay() {
+        surfaceTextureHelper.setTextureSize(width, height);
+        surfaceTextureHelper.getSurfaceTexture().setDefaultBufferSize(width, height);
+        virtualDisplay = mediaProjection.createVirtualDisplay("WebRTC_ScreenCapture", width, height,
+                VIRTUAL_DISPLAY_DPI, DISPLAY_FLAGS, new Surface(surfaceTextureHelper.getSurfaceTexture()),
+                null /* callback */, null /* callback handler */);
+    }
+
+    @Override
+    public boolean isScreencast() {
+        return true;
+    }
+
+    public long getNumCapturedFrames() {
+        return numCapturedFrames;
+    }
 }

--- a/lib/src/helper.dart
+++ b/lib/src/helper.dart
@@ -162,4 +162,13 @@ class Helper {
       AppleNativeAudioManagement.setAppleAudioConfiguration(
           AppleNativeAudioManagement.getAppleAudioConfigurationForMode(mode,
               preferSpeakerOutput: preferSpeakerOutput));
+
+  /// Request capture permission for Android
+  static Future<bool> requestCapturePermission() async {
+    if (WebRTC.platformIsAndroid) {
+      return await WebRTC.invokeMethod('requestCapturePermission');
+    } else {
+      throw Exception('requestCapturePermission only support for Android');
+    }
+  }
 }


### PR DESCRIPTION
After AOS 14, changeCaptureFormat() should resize the VirtualDisplay instead of recreating it due to the limitation on reusing MediaProjectionPermissionResultData. And it is necessary to obtain capture permission first and request foreground service; otherwise, the app crashes due to the media projection permission policy.
Use Helper.requestCapturePermission() to obtain capture permission on Android 14 specially targetSdkVersion 34 or above.

Tested on Android 13, 14 and targetSdkVersion 33, 34 combinations.