### PR TITLE
Fix handling of unimplemented method

### DIFF
--- a/common/cpp/include/flutter_frame_cryptor.h
+++ b/common/cpp/include/flutter_frame_cryptor.h
@@ -23,9 +23,11 @@ class FlutterFrameCryptor {
  public:
   FlutterFrameCryptor(FlutterWebRTCBase* base) : base_(base) {}
 
+  // Since this takes ownership of result, ownership will be passed back to 'outResult' if this function fails
   bool HandleFrameCryptorMethodCall(
     const MethodCallProxy& method_call,
-    std::unique_ptr<MethodResultProxy> result);
+    std::unique_ptr<MethodResultProxy> result,
+    std::unique_ptr<MethodResultProxy> *outResult);
 
   void FrameCryptorFactoryCreateFrameCryptor(
       const EncodableMap& constraints,

--- a/common/cpp/src/flutter_frame_cryptor.cc
+++ b/common/cpp/src/flutter_frame_cryptor.cc
@@ -48,7 +48,8 @@ void FlutterFrameCryptorObserver::OnFrameCryptionStateChanged(
 
 bool FlutterFrameCryptor::HandleFrameCryptorMethodCall(
     const MethodCallProxy& method_call,
-    std::unique_ptr<MethodResultProxy> result) {
+    std::unique_ptr<MethodResultProxy> result,
+    std::unique_ptr<MethodResultProxy> *outResult) {
   const std::string& method_name = method_call.method_name();
   if (!method_call.arguments()) {
     result->Error("Bad Arguments", "Null arguments received");
@@ -102,7 +103,8 @@ bool FlutterFrameCryptor::HandleFrameCryptorMethodCall(
     KeyProviderDispose(params, std::move(result));
     return true;
   }
-
+  
+  *outResult = std::move(result);
   return false;
 }
 

--- a/common/cpp/src/flutter_webrtc.cc
+++ b/common/cpp/src/flutter_webrtc.cc
@@ -1241,10 +1241,12 @@ void FlutterWebRTC::HandleMethodCall(
     state[EncodableValue("state")] =
         peerConnectionStateString(pc->peer_connection_state());
     result->Success(EncodableValue(state));
-  } else if (HandleFrameCryptorMethodCall(method_call, std::move(result))) {
-    // Do nothing
   } else {
-    result->NotImplemented();
+    if (HandleFrameCryptorMethodCall(method_call, std::move(result), &result)) {
+      return;
+    } else {
+      result->NotImplemented();
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #1504 
Fixes #1525

This fixes an issue in the handling of unimplemented methods. 

Because all unimplemented methods result in a call to `HandleFrameCryptorMethodCall`, which contains a `move` on the `result` pointer, if we later try to call `result.NotImplemented` it fails because `result` pointer was nullified during this move https://github.com/flutter-webrtc/flutter-webrtc/blob/81d3d845183c7e2884800477bc01414cc5778774/common/cpp/src/flutter_webrtc.cc#L1244

This fixes the issue by moving `result` back out of the function call in the case of `HandleFrameCryptorMethodCall` fails. Not sure how we feel about using out parameters like this, but this felt like the simplest fix to me. Open to suggestions for alternatives!