### PR TITLE
fix(Android): actually call selectAudioOutput in enableSpeakerButPreferBluetooth

### DIFF
--- a/android/src/main/java/com/cloudwebrtc/webrtc/audio/AudioSwitchManager.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/audio/AudioSwitchManager.java
@@ -269,6 +269,8 @@ public class AudioSwitchManager {
 
         if (audioDevice == null) {
             selectAudioOutput(AudioDevice.Speakerphone.class);
+        } else {
+            selectAudioOutput(audioDevice.getClass());
         }
     }
 


### PR DESCRIPTION
Without this call, `enableSpeakerButPreferBluetooth` doesn't do anything if it finds a headset