### PR TITLE
fix: fit cover works wrong

### DIFF
--- a/ios/Classes/FlutterRTCVideoPlatformView.m
+++ b/ios/Classes/FlutterRTCVideoPlatformView.m
@@ -29,7 +29,8 @@
         _videoView.videoContentMode = UIViewContentModeScaleAspectFit;
     } else if([index intValue] == 1) {
         // for Cover mode
-        _videoView.videoContentMode = UIViewContentModeCenter;
+        _videoView.contentMode = UIViewContentModeScaleAspectFit;
+        _videoView.videoContentMode = UIViewContentModeScaleAspectFill;
     }
 }
 

--- a/lib/src/native/rtc_video_platform_view.dart
+++ b/lib/src/native/rtc_video_platform_view.dart
@@ -41,32 +41,19 @@ class NativeVideoPlayerViewState extends State<RTCVideoPlatFormView> {
   }
 
   Widget _buildVideoView(BuildContext context, BoxConstraints constraints) {
-    return Center(
-      child: Container(
-        width: constraints.maxWidth *
-            (widget.objectFit ==
-                    RTCVideoViewObjectFit.RTCVideoViewObjectFitCover
-                ? _controller?.value.aspectRatio ?? 1.0
-                : 1.0),
-        height: constraints.maxHeight,
-        child: FittedBox(
-          clipBehavior: Clip.hardEdge,
-          fit: widget.objectFit ==
-                  RTCVideoViewObjectFit.RTCVideoViewObjectFitContain
+    return FittedBox(
+      clipBehavior: Clip.hardEdge,
+      fit:
+          widget.objectFit == RTCVideoViewObjectFit.RTCVideoViewObjectFitContain
               ? BoxFit.contain
               : BoxFit.cover,
-          child: Center(
-            child: SizedBox(
-              width: constraints.maxWidth,
-              height: constraints.maxHeight,
-              child: Transform(
-                transform: Matrix4.identity()
-                  ..rotateY(widget.mirror ? -pi : 0.0),
-                alignment: FractionalOffset.center,
-                child: _buildNativeView(),
-              ),
-            ),
-          ),
+      child: SizedBox(
+        width: constraints.maxWidth,
+        height: constraints.maxHeight,
+        child: Transform(
+          transform: Matrix4.identity()..rotateY(widget.mirror ? -pi : 0.0),
+          alignment: FractionalOffset.center,
+          child: _buildNativeView(),
         ),
       ),
     );


### PR DESCRIPTION
I tried `RTCVideoPlatFormView` and realized that objectFit is `cover` doesn't seem to work properly, `contain` does as expected. 

<img src="https://github.com/flutter-webrtc/flutter-webrtc/assets/60530946/17786573-b77b-4276-b563-93635650b716" width="250px"/>

After fix:

| Cover | Contain |
|-------|-------|
| <img src="https://github.com/flutter-webrtc/flutter-webrtc/assets/60530946/93f06b0c-44b0-4b2f-a660-452fc9c611ce" width="250px"/> | <img src="https://github.com/flutter-webrtc/flutter-webrtc/assets/60530946/b5995f90-9336-4a53-83f2-782218f22f09" width="250px"/> |