### PR TITLE
Supports video capturer stop and restart features on Android.

### DIFF
--- a/android/src/main/java/com/cloudwebrtc/webrtc/GetUserMediaImpl.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/GetUserMediaImpl.java
@@ -1267,6 +1267,30 @@ class GetUserMediaImpl {
         }
     }
 
+    void stopVideoCapturerSync(String id) {
+        synchronized (mVideoCapturers) {
+            VideoCapturerInfo info = mVideoCapturers.get(id);
+            if (info != null) {
+                try {
+                    info.capturer.stopCapture();
+                } catch (InterruptedException e) {
+                    Log.e(TAG, "stopVideoCapturerSync() Failed to stop video capturer");
+                } finally {
+                    SurfaceTextureHelper helper = mSurfaceTextureHelpers.get(id);
+                    if (helper != null) {
+                        helper.stopListening();
+                    }
+                }
+            }
+        }
+    }
+
+    void stopVideoCapturer(String id) {
+        new Thread(() -> {
+            stopVideoCapturerSync(id);
+        }).start();
+    }
+
     public void reStartCamera(IsCameraEnabled getCameraId) {
         for (Map.Entry<String, VideoCapturerInfo> item : mVideoCapturers.entrySet()) {
             if (!item.getValue().isScreenCapture && getCameraId.isEnabled(item.getKey())) {

--- a/android/src/main/java/com/cloudwebrtc/webrtc/MethodCallHandlerImpl.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/MethodCallHandlerImpl.java
@@ -566,6 +566,15 @@ public class MethodCallHandlerImpl implements MethodCallHandler, StateProvider {
         getUserMediaImpl.setTorch(trackId, torch, result);
         break;
       }
+      case "reStartCamera": {
+        reStartCamera();
+        break;
+      }
+      case "stopVideoCapturer": {
+        String trackId = call.argument("trackId");
+        getUserMediaImpl.stopVideoCapturer(trackId);
+        break;
+      }
       case "mediaStreamTrackSetZoom": {
         String trackId = call.argument("trackId");
         double zoomLevel = call.argument("zoomLevel");

--- a/lib/src/helper.dart
+++ b/lib/src/helper.dart
@@ -130,6 +130,25 @@ class Helper {
     return navigator.mediaDevices.getUserMedia(mediaConstraints);
   }
 
+  static Future<void> stopVideoCapturer(MediaStreamTrack videoTrack) async {
+    if (WebRTC.platformIsAndroid) {
+      await WebRTC.invokeMethod(
+        'stopVideoCapturer',
+        <String, dynamic>{'trackId': videoTrack.id},
+      );
+    } else {
+      throw Exception('stopVideoCapturer only support for Android');
+    }
+  }
+
+  static Future<void> reStartVideoCapturer(MediaStreamTrack videoTrack) async {
+    if (WebRTC.platformIsAndroid) {
+      await WebRTC.invokeMethod('reStartCamera');
+    } else {
+      throw Exception('reStartVideoCapturer only support for Android');
+    }
+  }
+
   /// Set the volume for Flutter native
   static Future<void> setVolume(double volume, MediaStreamTrack track) =>
       NativeAudioManagement.setVolume(volume, track);


### PR DESCRIPTION
Supports video capturer stop and restart features on Android. You must manually stop and restart the video capturer. Otherwise, after accessing the camera in another app, the camera won't reopen when you return to the app.

