### PR TITLE
Fixes #1611, Resolve running into a NullPointerException on finding RtpSender for sendDTMF

### DIFF
--- a/android/src/main/java/com/cloudwebrtc/webrtc/MethodCallHandlerImpl.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/MethodCallHandlerImpl.java
@@ -386,7 +386,7 @@ public class MethodCallHandlerImpl implements MethodCallHandler, StateProvider {
           RtpSender audioSender = null;
           for (RtpSender sender : peerConnection.getSenders()) {
 
-            if (sender.track().kind().equals("audio")) {
+            if (sender != null && sender.track() != null && sender.track().kind().equals("audio")) {
               audioSender = sender;
             }
           }


### PR DESCRIPTION
Check if RtpSender and its MediaStreamTrack from PeerConnection are not null when looking for a MediaStreamTrack of kind audio when finding a RtpSender to call insertDtmf in onMethodCall case: 'sendDTMF'.

