### PR TITLE
refactor: remove redundant init method in "loopback data channel" example

### DIFF
--- a/example/lib/src/loopback_data_channel_sample.dart
+++ b/example/lib/src/loopback_data_channel_sample.dart
@@ -21,10 +21,6 @@ class _DataChannelLoopBackSampleState extends State<DataChannelLoopBackSample> {
   String _dc2Status = '';
 
   bool _inCalling = false;
-  @override
-  void initState() {
-    super.initState();
-  }
 
   void _makeCall() async {
     if (_pc1 != null || _pc2 != null) return;


### PR DESCRIPTION
**STATUS**: Ready for review

---

The current example does:

```dart
  @override
  void initState() {
    super.initState();
  }
```

The above is redundant since there is no logic within the overridden `initState`.