### PR TITLE
refactor: remove unused OrientationBuilder in "loopback data channel" example

### DIFF
--- a/example/lib/src/loopback_data_channel_sample.dart
+++ b/example/lib/src/loopback_data_channel_sample.dart
@@ -130,23 +130,20 @@ class _DataChannelLoopBackSampleState extends State<DataChannelLoopBackSample> {
       appBar: AppBar(
         title: Text('Data Channel Test'),
       ),
-      body: OrientationBuilder(
-        builder: (context, orientation) {
-          return Center(
-              child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              Text('(caller)data channel 1:\n'),
-              Container(
-                child: Text(_dc1Status),
-              ),
-              Text('\n\n(callee)data channel 2:\n'),
-              Container(
-                child: Text(_dc2Status),
-              ),
-            ],
-          ));
-        },
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text('(caller)data channel 1:\n'),
+            Container(
+              child: Text(_dc1Status),
+            ),
+            Text('\n\n(callee)data channel 2:\n'),
+            Container(
+              child: Text(_dc2Status),
+            ),
+          ],
+        ),
       ),
       floatingActionButton: FloatingActionButton(
         onPressed: _inCalling ? _hangUp : _makeCall,


### PR DESCRIPTION
**STATUS**: Ready for review

---

The current example uses an `OrientationBuilder`, the builder provides an `orientation`, since this `orientation` value is unused the widget is useless.

Removing the widget clears the widget tree, making it more readable and simplifies the example for new readers.