### PR TITLE
Fixed critical error when opening/closing camera.

### DIFF
--- a/android/src/main/java/com/cloudwebrtc/webrtc/CameraEventsHandler.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/CameraEventsHandler.java
@@ -5,42 +5,80 @@ import android.util.Log;
 import org.webrtc.CameraVideoCapturer;
 
 class CameraEventsHandler implements CameraVideoCapturer.CameraEventsHandler {
+    public enum CameraState {
+        NEW,
+        OPENING,
+        OPENED,
+        CLOSED,
+        DISCONNECTED,
+        ERROR,
+        FREEZED
+    }
     private final static String TAG = FlutterWebRTCPlugin.TAG;
+    private CameraState state = CameraState.NEW;
+
+    public void waitForCameraOpen() {
+        Log.d(TAG, "CameraEventsHandler.waitForCameraOpen");
+        while (state != CameraState.OPENED && state != CameraState.ERROR) {
+            try {
+                Thread.sleep(1);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    public void waitForCameraClosed() {
+        Log.d(TAG, "CameraEventsHandler.waitForCameraClosed");
+        while (state != CameraState.CLOSED && state != CameraState.ERROR) {
+            try {
+                Thread.sleep(1);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        }
+    }
 
     // Camera error handler - invoked when camera can not be opened
     // or any camera exception happens on camera thread.
     @Override
     public void onCameraError(String errorDescription) {
         Log.d(TAG, String.format("CameraEventsHandler.onCameraError: errorDescription=%s", errorDescription));
+        state = CameraState.ERROR;
     }
 
     // Called when camera is disconnected.
     @Override
     public void onCameraDisconnected() {
         Log.d(TAG, "CameraEventsHandler.onCameraDisconnected");
+        state = CameraState.DISCONNECTED;
     }
 
     // Invoked when camera stops receiving frames
     @Override
     public void onCameraFreezed(String errorDescription) {
         Log.d(TAG, String.format("CameraEventsHandler.onCameraFreezed: errorDescription=%s", errorDescription));
+        state = CameraState.FREEZED;
     }
 
     // Callback invoked when camera is opening.
     @Override
     public void onCameraOpening(String cameraName) {
         Log.d(TAG, String.format("CameraEventsHandler.onCameraOpening: cameraName=%s", cameraName));
+        state = CameraState.OPENING;
     }
 
     // Callback invoked when first camera frame is available after camera is opened.
     @Override
     public void onFirstFrameAvailable() {
         Log.d(TAG, "CameraEventsHandler.onFirstFrameAvailable");
+        state = CameraState.OPENED;
     }
 
     // Callback invoked when camera closed.
     @Override
     public void onCameraClosed() {
         Log.d(TAG, "CameraEventsHandler.onFirstFrameAvailable");
+        state = CameraState.CLOSED;
     }
 }

--- a/android/src/main/java/com/cloudwebrtc/webrtc/GetUserMediaImpl.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/GetUserMediaImpl.java
@@ -270,7 +270,7 @@ class GetUserMediaImpl {
      * if not matched camera with specified facing mode.
      */
     private Map<String, VideoCapturer> createVideoCapturer(
-            CameraEnumerator enumerator, boolean isFacing, String sourceId) {
+            CameraEnumerator enumerator, boolean isFacing, String sourceId, CameraEventsHandler cameraEventsHandler) {
         VideoCapturer videoCapturer = null;
         Map<String, VideoCapturer> result = new HashMap<String, VideoCapturer>();
         // if sourceId given, use specified sourceId first
@@ -278,7 +278,7 @@ class GetUserMediaImpl {
         if (sourceId != null && !sourceId.equals("")) {
             for (String name : deviceNames) {
                 if (name.equals(sourceId)) {
-                    videoCapturer = enumerator.createCapturer(name, new CameraEventsHandler());
+                    videoCapturer = enumerator.createCapturer(name, cameraEventsHandler);
                     if (videoCapturer != null) {
                         Log.d(TAG, "create user specified camera " + name + " succeeded");
                         result.put(name, videoCapturer);
@@ -295,10 +295,9 @@ class GetUserMediaImpl {
         String facingStr = isFacing ? "front" : "back";
         for (String name : deviceNames) {
             if (enumerator.isFrontFacing(name) == isFacing) {
-                videoCapturer = enumerator.createCapturer(name, new CameraEventsHandler());
+                videoCapturer = enumerator.createCapturer(name, cameraEventsHandler);
                 if (videoCapturer != null) {
                     Log.d(TAG, "Create " + facingStr + " camera " + name + " succeeded");
-
                     result.put(name, videoCapturer);
                     return result;
                 } else {
@@ -309,7 +308,7 @@ class GetUserMediaImpl {
 
         // falling back to the first available camera
         if (videoCapturer == null && deviceNames.length > 0) {
-            videoCapturer = enumerator.createCapturer(deviceNames[0], new CameraEventsHandler());
+            videoCapturer = enumerator.createCapturer(deviceNames[0], cameraEventsHandler);
             Log.d(TAG, "Falling back to the first available camera");
             result.put(deviceNames[0], videoCapturer);
         }
@@ -741,15 +740,19 @@ class GetUserMediaImpl {
         String facingMode = getFacingMode(videoConstraintsMap);
         isFacing = facingMode == null || !facingMode.equals("environment");
         String deviceId = getSourceIdConstraint(videoConstraintsMap);
-
-        Map<String, VideoCapturer> result = createVideoCapturer(cameraEnumerator, isFacing, deviceId);
+        CameraEventsHandler cameraEventsHandler = new CameraEventsHandler();
+        Map<String, VideoCapturer> result = createVideoCapturer(cameraEnumerator, isFacing, deviceId, cameraEventsHandler);
 
         if (result == null) {
             return null;
         }
 
         if (deviceId == null) {
-            deviceId = result.keySet().iterator().next();
+            if(!result.keySet().isEmpty()) {
+                deviceId = result.keySet().iterator().next();
+            } else {
+                return null;
+            }
         }
 
         VideoCapturer videoCapturer = result.get(deviceId);
@@ -785,7 +788,10 @@ class GetUserMediaImpl {
                 ? videoConstraintsMandatory.getInt("minFrameRate")
                 : DEFAULT_FPS;
         info.capturer = videoCapturer;
+        info.cameraEventsHandler = cameraEventsHandler;
         videoCapturer.startCapture(info.width, info.height, info.fps);
+
+        cameraEventsHandler.waitForCameraOpen();
 
         String trackId = stateProvider.getNextTrackUUID();
         mVideoCapturers.put(trackId, info);
@@ -820,31 +826,30 @@ class GetUserMediaImpl {
     }
 
     void removeVideoCapturerSync(String id) {
-        synchronized (mVideoCapturers) {
-            VideoCapturerInfo info = mVideoCapturers.get(id);
-            if (info != null) {
-                try {
-                    info.capturer.stopCapture();
-                } catch (InterruptedException e) {
-                    Log.e(TAG, "removeVideoCapturer() Failed to stop video capturer");
-                } finally {
-                    info.capturer.dispose();
-                    mVideoCapturers.remove(id);
-                    SurfaceTextureHelper helper = mSurfaceTextureHelpers.get(id);
-                    if (helper != null) {
-                        helper.stopListening();
-                        helper.dispose();
-                        mSurfaceTextureHelpers.remove(id);
-                    }
+        VideoCapturerInfo info = mVideoCapturers.get(id);
+        if (info != null) {
+            try {
+                info.capturer.stopCapture();
+                if (info.cameraEventsHandler != null) {
+                    info.cameraEventsHandler.waitForCameraClosed();
+                }
+            } catch (InterruptedException e) {
+                Log.e(TAG, "removeVideoCapturer() Failed to stop video capturer");
+            } finally {
+                info.capturer.dispose();
+                mVideoCapturers.remove(id);
+                SurfaceTextureHelper helper = mSurfaceTextureHelpers.get(id);
+                if (helper != null) {
+                    helper.stopListening();
+                    helper.dispose();
+                    mSurfaceTextureHelpers.remove(id);
                 }
             }
         }
     }
 
     void removeVideoCapturer(String id) {
-        new Thread(() -> {
-            removeVideoCapturerSync(id);
-        }).start();
+        removeVideoCapturerSync(id);
     }
 
     @RequiresApi(api = VERSION_CODES.M)
@@ -1289,6 +1294,7 @@ class GetUserMediaImpl {
         int height;
         int fps;
         boolean isScreenCapture = false;
+        CameraEventsHandler cameraEventsHandler;
     }
 
     @RequiresApi(api = VERSION_CODES.M)

--- a/android/src/main/java/com/cloudwebrtc/webrtc/GetUserMediaImpl.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/GetUserMediaImpl.java
@@ -825,7 +825,7 @@ class GetUserMediaImpl {
         return trackParams;
     }
 
-    void removeVideoCapturerSync(String id) {
+    void removeVideoCapturer(String id) {
         VideoCapturerInfo info = mVideoCapturers.get(id);
         if (info != null) {
             try {
@@ -846,10 +846,6 @@ class GetUserMediaImpl {
                 }
             }
         }
-    }
-
-    void removeVideoCapturer(String id) {
-        removeVideoCapturerSync(id);
     }
 
     @RequiresApi(api = VERSION_CODES.M)

--- a/lib/src/native/adapter_type.dart
+++ b/lib/src/native/adapter_type.dart
@@ -1,5 +1,3 @@
-import 'package:flutter/foundation.dart';
-
 enum AdapterType {
   adapterTypeUnknown,
   adapterTypeEthernet,

--- a/lib/src/native/adapter_type.dart
+++ b/lib/src/native/adapter_type.dart
@@ -9,7 +9,3 @@ enum AdapterType {
   adapterTypeLoopback,
   adapterTypeAny
 }
-
-extension AdapterTypeExt on AdapterType {
-  String get value => describeEnum(this);
-}

--- a/lib/src/native/android/audio_configuration.dart
+++ b/lib/src/native/android/audio_configuration.dart
@@ -10,13 +10,9 @@ enum AndroidAudioMode {
   ringtone,
 }
 
-extension AndroidAudioModeExt on AndroidAudioMode {
-  String get value => describeEnum(this);
-}
-
 extension AndroidAudioModeEnumEx on String {
-  AndroidAudioMode toAndroidAudioMode() => AndroidAudioMode.values
-      .firstWhere((d) => describeEnum(d) == toLowerCase());
+  AndroidAudioMode toAndroidAudioMode() =>
+      AndroidAudioMode.values.firstWhere((d) => d.name == toLowerCase());
 }
 
 enum AndroidAudioFocusMode {
@@ -26,14 +22,9 @@ enum AndroidAudioFocusMode {
   gainTransientMayDuck
 }
 
-extension AndroidAudioFocusModeExt on AndroidAudioFocusMode {
-  String get value => describeEnum(this);
-}
-
 extension AndroidAudioFocusModeEnumEx on String {
   AndroidAudioFocusMode toAndroidAudioFocusMode() =>
-      AndroidAudioFocusMode.values
-          .firstWhere((d) => describeEnum(d) == toLowerCase());
+      AndroidAudioFocusMode.values.firstWhere((d) => d.name == toLowerCase());
 }
 
 enum AndroidAudioStreamType {
@@ -47,14 +38,9 @@ enum AndroidAudioStreamType {
   voiceCall
 }
 
-extension AndroidAudioStreamTypeExt on AndroidAudioStreamType {
-  String get value => describeEnum(this);
-}
-
 extension AndroidAudioStreamTypeEnumEx on String {
   AndroidAudioStreamType toAndroidAudioStreamType() =>
-      AndroidAudioStreamType.values
-          .firstWhere((d) => describeEnum(d) == toLowerCase());
+      AndroidAudioStreamType.values.firstWhere((d) => d.name == toLowerCase());
 }
 
 enum AndroidAudioAttributesUsageType {
@@ -73,15 +59,10 @@ enum AndroidAudioAttributesUsageType {
   voiceCommunicationSignalling
 }
 
-extension AndroidAudioAttributesUsageTypeExt
-    on AndroidAudioAttributesUsageType {
-  String get value => describeEnum(this);
-}
-
 extension AndroidAudioAttributesUsageTypeEnumEx on String {
   AndroidAudioAttributesUsageType toAndroidAudioAttributesUsageType() =>
       AndroidAudioAttributesUsageType.values
-          .firstWhere((d) => describeEnum(d) == toLowerCase());
+          .firstWhere((d) => d.name == toLowerCase());
 }
 
 enum AndroidAudioAttributesContentType {
@@ -92,15 +73,10 @@ enum AndroidAudioAttributesContentType {
   unknown
 }
 
-extension AndroidAudioAttributesContentTypeExt
-    on AndroidAudioAttributesContentType {
-  String get value => describeEnum(this);
-}
-
 extension AndroidAudioAttributesContentTypeEnumEx on String {
   AndroidAudioAttributesContentType toAndroidAudioAttributesContentType() =>
       AndroidAudioAttributesContentType.values
-          .firstWhere((d) => describeEnum(d) == toLowerCase());
+          .firstWhere((d) => d.name == toLowerCase());
 }
 
 class AndroidAudioConfiguration {
@@ -133,17 +109,17 @@ class AndroidAudioConfiguration {
   Map<String, dynamic> toMap() => <String, dynamic>{
         if (manageAudioFocus != null) 'manageAudioFocus': manageAudioFocus!,
         if (androidAudioMode != null)
-          'androidAudioMode': androidAudioMode!.value,
+          'androidAudioMode': androidAudioMode!.name,
         if (androidAudioFocusMode != null)
-          'androidAudioFocusMode': androidAudioFocusMode!.value,
+          'androidAudioFocusMode': androidAudioFocusMode!.name,
         if (androidAudioStreamType != null)
-          'androidAudioStreamType': androidAudioStreamType!.value,
+          'androidAudioStreamType': androidAudioStreamType!.name,
         if (androidAudioAttributesUsageType != null)
           'androidAudioAttributesUsageType':
-              androidAudioAttributesUsageType!.value,
+              androidAudioAttributesUsageType!.name,
         if (androidAudioAttributesContentType != null)
           'androidAudioAttributesContentType':
-              androidAudioAttributesContentType!.value,
+              androidAudioAttributesContentType!.name,
         if (forceHandleAudioRouting != null)
           'forceHandleAudioRouting': forceHandleAudioRouting!,
       };

--- a/lib/src/native/android/audio_configuration.dart
+++ b/lib/src/native/android/audio_configuration.dart
@@ -1,5 +1,3 @@
-import 'package:flutter/foundation.dart';
-
 import '../utils.dart';
 
 enum AndroidAudioMode {

--- a/lib/src/native/ios/audio_configuration.dart
+++ b/lib/src/native/ios/audio_configuration.dart
@@ -14,13 +14,9 @@ enum AppleAudioMode {
   voicePrompt,
 }
 
-extension AppleAudioModeExt on AppleAudioMode {
-  String get value => describeEnum(this);
-}
-
 extension AppleAudioModeEnumEx on String {
   AppleAudioMode toAppleAudioMode() =>
-      AppleAudioMode.values.firstWhere((d) => describeEnum(d) == toLowerCase());
+      AppleAudioMode.values.firstWhere((d) => d.name == toLowerCase());
 }
 
 enum AppleAudioCategory {
@@ -31,13 +27,9 @@ enum AppleAudioCategory {
   multiRoute,
 }
 
-extension AppleAudioCategoryExt on AppleAudioCategory {
-  String get value => describeEnum(this);
-}
-
 extension AppleAudioCategoryEnumEx on String {
-  AppleAudioCategory toAppleAudioCategory() => AppleAudioCategory.values
-      .firstWhere((d) => describeEnum(d) == toLowerCase());
+  AppleAudioCategory toAppleAudioCategory() =>
+      AppleAudioCategory.values.firstWhere((d) => d.name == toLowerCase());
 }
 
 enum AppleAudioCategoryOption {
@@ -50,14 +42,10 @@ enum AppleAudioCategoryOption {
   defaultToSpeaker,
 }
 
-extension AppleAudioCategoryOptionExt on AppleAudioCategoryOption {
-  String get value => describeEnum(this);
-}
-
 extension AppleAudioCategoryOptionEnumEx on String {
   AppleAudioCategoryOption toAppleAudioCategoryOption() =>
       AppleAudioCategoryOption.values
-          .firstWhere((d) => describeEnum(d) == toLowerCase());
+          .firstWhere((d) => d.name == toLowerCase());
 }
 
 class AppleAudioConfiguration {
@@ -72,11 +60,11 @@ class AppleAudioConfiguration {
 
   Map<String, dynamic> toMap() => <String, dynamic>{
         if (appleAudioCategory != null)
-          'appleAudioCategory': appleAudioCategory!.value,
+          'appleAudioCategory': appleAudioCategory!.name,
         if (appleAudioCategoryOptions != null)
           'appleAudioCategoryOptions':
-              appleAudioCategoryOptions!.map((e) => e.value).toList(),
-        if (appleAudioMode != null) 'appleAudioMode': appleAudioMode!.value,
+              appleAudioCategoryOptions!.map((e) => e.name).toList(),
+        if (appleAudioMode != null) 'appleAudioMode': appleAudioMode!.name,
       };
 }
 

--- a/lib/src/native/ios/audio_configuration.dart
+++ b/lib/src/native/ios/audio_configuration.dart
@@ -1,5 +1,3 @@
-import 'package:flutter/foundation.dart';
-
 import '../utils.dart';
 
 enum AppleAudioMode {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   collection: ^1.17.0
-  dart_webrtc: ^1.4.6
+  dart_webrtc: ^1.4.8
   flutter:
     sdk: flutter
   path_provider: ^2.0.2


### PR DESCRIPTION
When the camera is opened or closed quickly, `getUserMedia` will be stuck in the camera opening state, so we need to confirm that the camera has been fully opened or closed when `getUserMedia` or `track.stop()`.