### PR TITLE
fix: race condition in RTCVideoRenderer for Web

### DIFF
--- a/lib/src/web/rtc_video_renderer_impl.dart
+++ b/lib/src/web/rtc_video_renderer_impl.dart
@@ -92,12 +92,12 @@ class RTCVideoRenderer extends ValueNotifier<RTCVideoValue>
 
   String get viewType => 'RTCVideoRenderer-$textureId';
 
-  void _updateAllValues() {
-    final element = findHtmlView();
+  void _updateAllValues(web.HTMLVideoElement fallback) {
+    final element = findHtmlView() ?? fallback;
     value = value.copyWith(
       rotation: 0,
-      width: element?.videoWidth.toDouble() ?? 0.0,
-      height: element?.videoHeight.toDouble() ?? 0.0,
+      width: element.videoWidth.toDouble(),
+      height: element.videoHeight.toDouble(),
       renderVideo: renderVideo,
     );
   }
@@ -273,13 +273,13 @@ class RTCVideoRenderer extends ValueNotifier<RTCVideoValue>
 
       _subscriptions.add(
         element.onCanPlay.listen((dynamic _) {
-          _updateAllValues();
+          _updateAllValues(element);
         }),
       );
 
       _subscriptions.add(
         element.onResize.listen((dynamic _) {
-          _updateAllValues();
+          _updateAllValues(element);
           onResize?.call();
         }),
       );


### PR DESCRIPTION
sometimes video callbacks (onResize, onCanPlay) come before element is findable in DOM. This PR adds
the created element as fallback

fixes #1804