### PR TITLE
[Android] fix: remove setPreferredInputDevice when getUserAduio.

### DIFF
--- a/android/src/main/java/com/cloudwebrtc/webrtc/GetUserMediaImpl.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/GetUserMediaImpl.java
@@ -365,17 +365,6 @@ public class GetUserMediaImpl {
         String trackId = stateProvider.getNextTrackUUID();
         PeerConnectionFactory pcFactory = stateProvider.getPeerConnectionFactory();
         AudioSource audioSource = pcFactory.createAudioSource(audioConstraints);
-
-        if (deviceId != null) {
-            try {
-                if (VERSION.SDK_INT >= VERSION_CODES.M) {
-                    setPreferredInputDevice(deviceId);
-                }
-            } catch (Exception e) {
-                Log.e(TAG, "setPreferredInputDevice failed", e);
-            }
-        }
-
         AudioTrack track = pcFactory.createAudioTrack(trackId, audioSource);
         stream.addTrack(track);
 


### PR DESCRIPTION
Calling `setPreferredInputDevice` will cause HW AEC/NS failure on some devices, causing echo during voice calls. Known devices include Galaxy S25 Ultra, Galaxy Z Fold6.

In addition, we should avoid using [Helper.selectAudioInput](https://github.com/flutter-webrtc/flutter-webrtc/blob/main/lib/src/helper.dart#L108) during a call to avoid causing echo cancellation failure on these devices.