### PR TITLE
Resolve android corrupted recordings

### DIFF
--- a/android/src/main/java/com/cloudwebrtc/webrtc/record/VideoFileRenderer.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/record/VideoFileRenderer.java
@@ -1,3 +1,5 @@
+// Modifications by Signify, Copyright 2025, Signify Holding -  SPDX-License-Identifier: MIT
+
 package com.cloudwebrtc.webrtc.record;
 
 import android.media.MediaCodec;
@@ -19,6 +21,7 @@ import org.webrtc.audio.JavaAudioDeviceModule.SamplesReadyCallback;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.concurrent.CountDownLatch;
 
 class VideoFileRenderer implements VideoSink, SamplesReadyCallback {
     private static final String TAG = "VideoFileRenderer";
@@ -127,27 +130,47 @@ class VideoFileRenderer implements VideoSink, SamplesReadyCallback {
     /**
      * Release all resources. All already posted frames will be rendered first.
      */
+    // Start Signify modification
     void release() {
         isRunning = false;
-        if (audioThreadHandler != null)
+        CountDownLatch latch = new CountDownLatch(audioThreadHandler  != null ? 2 : 1);
+        if (audioThreadHandler != null) {
             audioThreadHandler.post(() -> {
-                if (audioEncoder != null) {
-                    audioEncoder.stop();
-                    audioEncoder.release();
+                try{
+                    if (audioEncoder != null) {
+                        audioEncoder.stop();
+                        audioEncoder.release();
+                    }
+                    audioThread.quit();
+                } finally {
+                    latch.countDown();
                 }
-                audioThread.quit();
             });
+        }
+
         renderThreadHandler.post(() -> {
-            if (encoder != null) {
-                encoder.stop();
-                encoder.release();
+            try {
+                if (encoder != null) {
+                    encoder.stop();
+                    encoder.release();
+                }
+                eglBase.release();
+                mediaMuxer.stop();
+                mediaMuxer.release();
+                renderThread.quit();
+            } finally {
+                latch.countDown();
             }
-            eglBase.release();
-            mediaMuxer.stop();
-            mediaMuxer.release();
-            renderThread.quit();
         });
+
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            Log.e(TAG, "Release interrupted", e);
+            Thread.currentThread().interrupt();
+        }
     }
+    // End Signify modification
 
     private boolean encoderStarted = false;
     private volatile boolean muxerStarted = false;


### PR DESCRIPTION
The current stop function does not wait for the recording process to fully stop before proceeding. This can lead to corrupted files, as the audio or video thread may still be accessing the file when the app attempts to move it to the user's Movies directory. This MR updates the stop function to ensure it waits for the recording to completely stop, preventing file corruption.