### PR TITLE
fix: calls in terminated mode by disabling orientation manager

### DIFF
--- a/android/src/main/java/com/cloudwebrtc/webrtc/video/camera/CameraUtils.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/video/camera/CameraUtils.java
@@ -45,7 +45,14 @@ public class CameraUtils {
     this.getUserMediaImpl = getUserMediaImpl;
     this.activity = activity;
     this.deviceOrientationManager = new DeviceOrientationManager(activity, 0);
-    this.deviceOrientationManager.start();
+    // commented out because you cannot register a reciever when the app is terminated
+    // because the activity is null?
+    // this causes the call to break if the app is terminated
+    // the manager seems to end up at handleOrientationChange which does not do
+    // anything at the moment so this should be ok
+
+    // TODO: get a proper fix at some point
+    // this.deviceOrientationManager.start();
   }
 
   public void setFocusMode(MethodCall call, AnyThreadResult result) {


### PR DESCRIPTION
I don't have a better solution at the moment, but `handleOrientationChange` looks empty so this should be ok.

Fixes: https://github.com/flutter-webrtc/flutter-webrtc/issues/1744, https://github.com/flutter-webrtc/flutter-webrtc/issues/1799