### PR TITLE
Ensure both video and audio tracks are added before starting the muxer

### DIFF
--- a/android/src/main/java/com/cloudwebrtc/webrtc/record/VideoFileRenderer.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/record/VideoFileRenderer.java
@@ -200,7 +200,9 @@ class VideoFileRenderer implements VideoSink, SamplesReadyCallback {
 
                 Log.e(TAG, "encoder output format changed: " + newFormat);
                 trackIndex = mediaMuxer.addTrack(newFormat);
-                if (trackIndex != -1 && !muxerStarted) {
+                // Start Signify modification
+                if (trackIndex != -1 && audioTrackIndex != -1 && !muxerStarted) {
+                // End Signify modification
                     mediaMuxer.start();
                     muxerStarted = true;
                 }
@@ -256,7 +258,9 @@ class VideoFileRenderer implements VideoSink, SamplesReadyCallback {
 
                 Log.w(TAG, "encoder output format changed: " + newFormat);
                 audioTrackIndex = mediaMuxer.addTrack(newFormat);
-                if (audioTrackIndex != -1 && !muxerStarted) {
+                // Start Signify modification
+                if (trackIndex != -1 && audioTrackIndex != -1 && !muxerStarted) {
+                // End Signify modification
                     mediaMuxer.start();
                     muxerStarted = true;
                 }


### PR DESCRIPTION
Previously, the code started the muxer as soon as either the audio or video track was added, which could cause the app to crash. The updated logic ensures that the muxer only starts after both the audio and video tracks have been added.