### PR TITLE
release: 1.0.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 [1.0.0] - 2025-07-25
 
 * Bump version to 1.0.0
-* [Native] chore: Upgrade libwebrtc to m137.
-* [Doc] Fix: typo in package description (#1895)
+* [Native] feat: Upgrade libwebrtc to m137. (#1877).
+* [Doc] fix: typo in package description (#1895)
 * [Android] fix: Video recording crashing and freezing on Android 14 Devices (#1886)
 * [Android] fix: Add audio recording for Android Platform (#1884)
 * [Dart] fix: Removed outdated code to avoid UI not being displayed in Windows release mode (#1890)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 
 # Changelog
 
+[1.0.0] - 2025-07-25
+
+* Bump version to 1.0.0
+* [Native] chore: Upgrade libwebrtc to m137.
+* [Doc] Fix: typo in package description (#1895)
+* [Android] fix: Video recording crashing and freezing on Android 14 Devices (#1886)
+* [Android] fix: Add audio recording for Android Platform (#1884)
+* [Dart] fix: Removed outdated code to avoid UI not being displayed in Windows release mode (#1890)
+* [Apple] fix: Fix compile warnings (#1887)
+* [Apple] feat: Update to m137 with audio engine (#1875)
+* [Android] fix: Ensure both video and audio tracks are added before starting the muxer (#1879)
+
 [0.14.2] - 2025-07-01
 
 * [Windows/Linux] feat: Add audio processing and sink API for cpp. (#1867)

--- a/ios/flutter_webrtc.podspec
+++ b/ios/flutter_webrtc.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'flutter_webrtc'
-  s.version          = '0.15.1'
+  s.version          = '1.0.0'
   s.summary          = 'Flutter WebRTC plugin for iOS.'
   s.description      = <<-DESC
 A new flutter plugin project.

--- a/macos/flutter_webrtc.podspec
+++ b/macos/flutter_webrtc.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'flutter_webrtc'
-  s.version          = '0.15.1'
+  s.version          = '1.0.0'
   s.summary          = 'Flutter WebRTC plugin for macOS.'
   s.description      = <<-DESC
 A new flutter plugin project.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_webrtc
 description: Flutter WebRTC plugin for iOS/Android/Desktop/Web, based on GoogleWebRTC.
-version: 0.14.2
+version: 1.0.0
 homepage: https://github.com/cloudwebrtc/flutter-webrtc
 environment:
   sdk: ">=3.3.0 <4.0.0"


### PR DESCRIPTION
[1.0.0] - 2025-07-25

* Bump version to 1.0.0
* [Native] feat: Upgrade libwebrtc to m137. (#1877).
* [Doc] Fix: typo in package description (#1895)
* [Android] fix: Video recording crashing and freezing on Android 14 Devices (#1886)
* [Android] fix: Add audio recording for Android Platform (#1884)
* [Dart] fix: Removed outdated code to avoid UI not being displayed in Windows release mode (#1890)
* [Apple] fix: Fix compile warnings (#1887)
* [Apple] feat: Update to m137 with audio engine (#1875)
* [Android] fix: Ensure both video and audio tracks are added before starting the muxer (#1879)