### PR TITLE
RECORDINGS - Add fallback resolutions for unsupported stream frame sizes on low-end Android devices

### DIFF
--- a/android/src/main/java/com/cloudwebrtc/webrtc/record/VideoFileRenderer.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/record/VideoFileRenderer.java
@@ -21,6 +21,9 @@ import org.webrtc.audio.JavaAudioDeviceModule.SamplesReadyCallback;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 
 class VideoFileRenderer implements VideoSink, SamplesReadyCallback {


### PR DESCRIPTION
This PR adds fallback resolutions to handle cases where the default stream frame resolution is not supported by the device. This issue typically occurs on low-end Android devices that lack support for higher resolutions. With this change, the system will automatically attempt to use compatible resolutions to ensure stream encoding continues without crashing.

Example:
If the original stream resolution is QHD and the encoder fails to configure it, the system will automatically fallback to FHD and try again. This process continues down the list of fallback resolutions until one is successfully configured.