### PR TITLE
fix: java.lang.ClassNotFoundException: org.jni_zero.JniInit

### DIFF
--- a/android/proguard-rules.pro
+++ b/android/proguard-rules.pro
@@ -1,3 +1,4 @@
 # Flutter WebRTC
 -keep class com.cloudwebrtc.webrtc.** { *; }
 -keep class org.webrtc.** { *; }
+-keep class org.jni_zero.** { *; }


### PR DESCRIPTION
to fix 
`java.lang.ClassNotFoundException: org.jni_zero.JniInit`
error in android release builds for version 1.0.0 (flutter_webrtc: ^1.0.0)