### PR TITLE
fix: Remove Bluetooth permission from AudioSwitch

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -53,7 +53,7 @@ android {
 
 dependencies {
     implementation 'io.github.webrtc-sdk:android:137.7151.01'
-    implementation 'com.github.davidliu:audioswitch:89582c47c9a04c62f90aa5e57251af4800a62c9a'
+    implementation 'com.github.Lucifer1091:audioswitch:a8c6f89d755b5bcbbacff489ef4df19395199225'
     implementation 'androidx.annotation:annotation:1.1.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }


### PR DESCRIPTION
This commit upgrades the AudioSwitch library.

The BLUETOOTH permission is no longer needed for apps targeting Android 12 (API 31) and above. It has been replaced by more specific permissions such as BLUETOOTH_SCAN, BLUETOOTH_CONNECT, and BLUETOOTH_ADVERTISE.

This change removes the legacy BLUETOOTH permission from the manifest.