### PR TITLE
Add texture-based video rendering for web (resurface #1670)

### DIFF
--- a/lib/src/web/rtc_video_view_impl.dart
+++ b/lib/src/web/rtc_video_view_impl.dart
@@ -1,8 +1,13 @@
 import 'dart:async';
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+import 'dart:ui' as ui;
+import 'dart:ui_web' as ui_web;
 
 import 'package:flutter/material.dart';
 
 import 'package:dart_webrtc/dart_webrtc.dart';
+import 'package:web/web.dart' as web;
 import 'package:webrtc_interface/webrtc_interface.dart';
 
 import 'rtc_video_renderer_impl.dart';
@@ -41,16 +46,96 @@ class RTCVideoViewState extends State<RTCVideoView> {
         widget.objectFit == RTCVideoViewObjectFit.RTCVideoViewObjectFitContain
             ? 'contain'
             : 'cover';
+
+    videoElement =
+        web.document.getElementById("video_${videoRenderer.viewType}")
+            as web.HTMLVideoElement?;
+    frameCallback(0.toJS, 0.toJS);
   }
 
   void _onRendererListener() {
     if (mounted) setState(() {});
   }
 
+  int? callbackID;
+
+  void getFrame(web.HTMLVideoElement element) {
+    callbackID =
+        element.requestVideoFrameCallbackWithFallback(frameCallback.toJS);
+  }
+
+  void cancelFrame(web.HTMLVideoElement element) {
+    if (callbackID != null) {
+      element.cancelVideoFrameCallbackWithFallback(callbackID!);
+    }
+  }
+
+  void frameCallback(JSAny now, JSAny metadata) {
+    final web.HTMLVideoElement? element = videoElement;
+    if (element != null) {
+      // only capture frames if video is playing (optimization for RAF)
+      if (element.readyState > 2) {
+        capture().then((_) async {
+          getFrame(element);
+        });
+      } else {
+        getFrame(element);
+      }
+    } else {
+      if (mounted) {
+        Future.delayed(Duration(milliseconds: 100)).then((_) {
+          frameCallback(0.toJS, 0.toJS);
+        });
+      }
+    }
+  }
+
+  ui.Image? capturedFrame;
+  num? lastFrameTime;
+  Future<void> capture() async {
+    final element = videoElement!;
+    if (lastFrameTime != element.currentTime) {
+      lastFrameTime = element.currentTime;
+      try {
+        final ui.Image img = await ui_web.createImageFromTextureSource(element,
+            width: element.videoWidth,
+            height: element.videoHeight,
+            transferOwnership: true);
+
+        if (mounted) {
+          setState(() {
+            capturedFrame?.dispose();
+            capturedFrame = img;
+          });
+        }
+      } on web.DOMException catch (err) {
+        lastFrameTime = null;
+        if (err.name == 'InvalidStateError') {
+          // We don't have enough data yet, continue on
+        } else {
+          rethrow;
+        }
+      }
+    }
+  }
+
   @override
   void dispose() {
     if (mounted) {
       super.dispose();
+    }
+    capturedFrame?.dispose();
+    if (videoElement != null) {
+      cancelFrame(videoElement!);
+    }
+  }
+
+  Size? size;
+
+  void updateElement() {
+    if (videoElement != null && size != null) {
+      videoElement!.width = size!.width.toInt();
+      videoElement!.height = size!.height.toInt();
     }
   }
 
@@ -65,8 +150,40 @@ class RTCVideoViewState extends State<RTCVideoView> {
             : 'cover';
   }
 
+  web.HTMLVideoElement? videoElement;
+
   Widget buildVideoElementView() {
-    return HtmlElementView(viewType: videoRenderer.viewType);
+    if (useHtmlElementView) {
+      return HtmlElementView(viewType: videoRenderer.viewType);
+    } else {
+      return LayoutBuilder(builder: (context, constraints) {
+        if (videoElement != null && size != constraints.biggest) {
+          size = constraints.biggest;
+          updateElement();
+        }
+
+        return Stack(children: [
+          if (capturedFrame != null)
+            Positioned.fill(
+                child: FittedBox(
+                    fit: switch (widget.objectFit) {
+                      RTCVideoViewObjectFit.RTCVideoViewObjectFitContain =>
+                        BoxFit.contain,
+                      RTCVideoViewObjectFit.RTCVideoViewObjectFitCover =>
+                        BoxFit.cover,
+                    },
+                    child: SizedBox(
+                        width: capturedFrame!.width.toDouble(),
+                        height: capturedFrame!.height.toDouble(),
+                        child: CustomPaint(
+                            willChange: true,
+                            painter: _ImageFlipPainter(
+                              capturedFrame!,
+                              widget.mirror,
+                            )))))
+        ]);
+      });
+    }
   }
 
   @override
@@ -84,5 +201,55 @@ class RTCVideoViewState extends State<RTCVideoView> {
         );
       },
     );
+  }
+}
+
+typedef _VideoFrameRequestCallback = JSFunction;
+
+extension _HTMLVideoElementRequestAnimationFrame on web.HTMLVideoElement {
+  int requestVideoFrameCallbackWithFallback(
+      _VideoFrameRequestCallback callback) {
+    if (hasProperty('requestVideoFrameCallback'.toJS).toDart) {
+      return requestVideoFrameCallback(callback);
+    } else {
+      return web.window.requestAnimationFrame((double num) {
+        callback.callAsFunction(this, 0.toJS, 0.toJS);
+      }.toJS);
+    }
+  }
+
+  void cancelVideoFrameCallbackWithFallback(int callbackID) {
+    if (hasProperty('requestVideoFrameCallback'.toJS).toDart) {
+      cancelVideoFrameCallback(callbackID);
+    } else {
+      web.window.cancelAnimationFrame(callbackID);
+    }
+  }
+
+  external int requestVideoFrameCallback(_VideoFrameRequestCallback callback);
+  external void cancelVideoFrameCallback(int callbackID);
+}
+
+class _ImageFlipPainter extends CustomPainter {
+  _ImageFlipPainter(this.image, this.flip);
+
+  final ui.Image image;
+  final bool flip;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    if (flip) {
+      canvas.scale(-1, 1);
+      canvas.drawImage(image, Offset(-size.width, 0),
+          Paint()..filterQuality = ui.FilterQuality.high);
+    } else {
+      canvas.drawImage(
+          image, Offset(0, 0), Paint()..filterQuality = ui.FilterQuality.high);
+    }
+  }
+
+  @override
+  bool shouldRepaint(CustomPainter oldDelegate) {
+    return false;
   }
 }


### PR DESCRIPTION
## Summary

Resurfaces @jezell's texture-based video rendering from #1670. Fixes camera rendering failures in large meetings, reduces DOM overhead, enables native Flutter compositing, and adds shader/effect support for video.

## Changes

- **New default**: Video frames captured from hidden HTML elements and painted via CustomPaint
- **Performance**: Solves rendering failures in large meetings (livekit/client-sdk-flutter#465)
- **Effects support**: Cameras work with Flutter renderer for shaders/blurs
- **Fallback**: Original behavior via `WEBRTC_USE_HTML_ELEMENT_VIEW=true`

## Implementation

- Frame capturing using `createImageFromTextureSource()`
- `requestVideoFrameCallback` with `requestAnimationFrame` fallback
- Smart caching - only captures when video time changes
- Custom painter for mirroring support

## Credits

Original work by @jezell in #1670

## Related

- Closes livekit/client-sdk-flutter#465
- Resurfaces #1670
