### PR TITLE
Reduce Recording Stop Delay and Prevent Encoder OOM Crashes (Android)

### DIFF
--- a/android/src/main/java/com/cloudwebrtc/webrtc/record/EncoderConfig.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/record/EncoderConfig.java
@@ -1,0 +1,20 @@
+package com.cloudwebrtc.webrtc.record;
+
+class EncoderConfig {
+    final int width;
+    final int height;
+    final int bitrate;
+    final int profile;
+
+    EncoderConfig(int width, int height, int bitrate, int profile) {
+        this.width = width;
+        this.height = height;
+        this.bitrate = bitrate;
+        this.profile = profile;
+    }
+
+    @Override
+    public String toString() {
+        return width + "x" + height + ", bitrate: " + bitrate + ", profile: " + profile;
+    }
+}

--- a/android/src/main/java/com/cloudwebrtc/webrtc/record/VideoFileRenderer.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/record/VideoFileRenderer.java
@@ -416,7 +416,7 @@ class VideoFileRenderer implements VideoSink, SamplesReadyCallback {
     }
 
     private long presTime = 0L;
-    private int drainCounter = 0;
+    
 
 
     private void drainAudio() {


### PR DESCRIPTION
This PR addresses two major issues related to recording:

- **Long delay when stopping the recording:** The timeout used in dequeueOutputBuffer was set to 10 seconds, which caused significant delays during stop. Reducing it to 1 second eliminated the issue
- **Frequent crashes due to MediaCodec out-of-memory errors:** The encoder was crashing with the following error:

> E/MediaCodec(26452): Codec reported err 0xfffffff4/NO_MEMORY, actionCode 0, while in state 5/STARTING
E/AndroidRuntime(26452): FATAL EXCEPTION: VideoFileRendererRenderThread
E/AndroidRuntime(26452): android.media.MediaCodec$CodecException: start failed
E/AndroidRuntime(26452): 	at android.media.MediaCodec.native_start(Native Method)
E/AndroidRuntime(26452): 	at android.media.MediaCodec.start(MediaCodec.java:2322)
E/AndroidRuntime(26452): 	at com.cloudwebrtc.webrtc.record.VideoFileRenderer.drainEncoder(VideoFileRenderer.java:232)
E/AndroidRuntime(26452): 	at com.cloudwebrtc.webrtc.record.VideoFileRenderer.renderFrameOnRenderThread(VideoFileRenderer.java:171)
E/AndroidRuntime(26452): 	at com.cloudwebrtc.webrtc.record.VideoFileRenderer.lambda$onFrame$1$com-cloudwebrtc-webrtc-record-VideoFileRenderer(VideoFileRenderer.java:156)

This was caused by missing configuration steps before calling start() on the encoder. The issue was resolved by moving additional configuration logic prior to starting the encoder.