### PR TITLE
release: 1.1.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 
 # Changelog
 
+[1.1.0] - 2025-08-20
+
+* [Apple/Android] feat: Add H265/HEVC support.
+* [Mobile/Desktop] feat: Support write logs with Logger (logger package) (#1891)
+* [Android] fix: Reduce Recording Stop Delay and Prevent Encoder OOM Crashes (Android) (#1912)
+* [Native/Web] feat: small setVolume addition (#1904)
+* [Web] feat: Add texture-based video rendering for web (#1911)
+* [Android] fix: RECORDINGS - Add fallback resolutions for unsupported stream frame sizes on low-end Android devices (#1900)
+* [Android] fix: Update proguard-rules.pro (#1902)
+
 [1.0.0] - 2025-07-25
 
 * Bump version to 1.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_webrtc
 description: Flutter WebRTC plugin for iOS/Android/Desktop/Web, based on GoogleWebRTC.
-version: 1.0.0
+version: 1.1.0
 homepage: https://github.com/cloudwebrtc/flutter-webrtc
 environment:
   sdk: ">=3.3.0 <4.0.0"


### PR DESCRIPTION
[1.1.0] - 2025-08-20

* [Apple/Android] feat: Add H265/HEVC support.
* [Mobile/Desktop] feat: Support write logs with Logger (logger package) (#1891)
* [Android] fix: Reduce Recording Stop Delay and Prevent Encoder OOM Crashes (Android) (#1912)
* [Native/Web] feat: small setVolume addition (#1904)
* [Web] feat: Add texture-based video rendering for web (#1911)
* [Android] fix: RECORDINGS - Add fallback resolutions for unsupported stream frame sizes on low-end Android devices (#1900)
* [Android] fix: Update proguard-rules.pro (#1902)