### PR TITLE
fix: clip hard edge on web's rtc_video_view

### DIFF
--- a/lib/src/web/rtc_video_view_impl.dart
+++ b/lib/src/web/rtc_video_view_impl.dart
@@ -172,6 +172,7 @@ class RTCVideoViewState extends State<RTCVideoView> {
                       RTCVideoViewObjectFit.RTCVideoViewObjectFitCover =>
                         BoxFit.cover,
                     },
+                    clipBehavior: Clip.hardEdge,
                     child: SizedBox(
                         width: capturedFrame!.width.toDouble(),
                         height: capturedFrame!.height.toDouble(),


### PR DESCRIPTION
This PR fixes an issue where iOS Safari video box renders would exceed the boundaries set by the `RTCVideoViewObjectFit.RTCVideoViewObjectFitContain` and `RTCVideoViewObjectFit.RTCVideoViewObjectFitCover` guidelines.

In the following examples (iOS Safari), I have specified the following:
```dart
rtc.RTCVideoView(
  _renderer! as rtc.RTCVideoRenderer,
  mirror: true,
  filterQuality: FilterQuality.medium,
  objectFit: RTCVideoViewObjectFit.RTCVideoViewObjectFitCover,
);
```

**Before this PR**
![IMG_0061 Medium](https://github.com/user-attachments/assets/cd4c5e3a-f915-4c00-a559-71163b384b75)
![IMG_0062 Medium](https://github.com/user-attachments/assets/21077d4c-94fa-476a-9486-8783f6f919e7)

**After this PR**
![IMG_0059 Medium](https://github.com/user-attachments/assets/b8050c80-9739-412c-839c-d25cf4d08cb6)
![IMG_0060 Medium](https://github.com/user-attachments/assets/ec212d4b-e763-480e-95cd-5087006ceb28)

