### PR TITLE
chore(android): support AGP 9 built-in Kotlin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 [Unreleased]
 
+* [Android] Support AGP 9's built-in Kotlin: apply the Kotlin Gradle Plugin only when built-in Kotlin is inactive (AGP < 9, or AGP 9 with `android.builtInKotlin=false`), set the JVM target through the `kotlin { compilerOptions {} }` DSL when available, and fall back to the legacy `kotlinOptions` DSL for apps still on Kotlin Gradle Plugin 1.8.x.
 * [Windows/Linux] fix: Map echoCancellation/noiseSuppression/autoGainControl constraints to RTCAudioOptions so software AEC/NS/AGC can actually be toggled from Dart (#XXXX).
 
 [1.4.1] -2026-03-24

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,14 +2,14 @@ group 'com.cloudwebrtc.webrtc'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.8.10'
+    ext.kotlin_version = '2.1.0'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.1'
+        classpath 'com.android.tools.build:gradle:8.1.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -23,7 +23,18 @@ rootProject.allprojects {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+
+// AGP 9's built-in Kotlin compiles Kotlin itself and rejects the Kotlin Gradle
+// Plugin. Apply KGP only when built-in Kotlin is NOT active: that means AGP < 9,
+// or AGP 9 with android.builtInKotlin=false (the configuration Flutter currently
+// ships by default while the ecosystem migrates).
+def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
+def builtInKotlinActive = agpMajor >= 9 &&
+    (!project.hasProperty('android.builtInKotlin') ||
+        Boolean.parseBoolean(project.property('android.builtInKotlin').toString()))
+if (!builtInKotlinActive) {
+    apply plugin: 'kotlin-android'
+}
 
 android {
     if (project.android.hasProperty("namespace")) {
@@ -45,9 +56,21 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+}
 
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8
+// Configure the Kotlin JVM target. The compilerOptions DSL requires KGP 1.9+ or
+// AGP 9 built-in Kotlin; older Flutter app templates ship KGP 1.8.x, which only
+// supports the legacy kotlinOptions DSL.
+def kotlinExt = project.extensions.findByName('kotlin')
+if (kotlinExt?.hasProperty('compilerOptions')) {
+    kotlin {
+        compilerOptions {
+            jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8
+        }
+    }
+} else {
+    android.kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_1_8.toString()
     }
 }
 
@@ -55,5 +78,4 @@ dependencies {
     implementation 'io.github.webrtc-sdk:android:144.7559.04'
     implementation 'com.github.davidliu:audioswitch:89582c47c9a04c62f90aa5e57251af4800a62c9a'
     implementation 'androidx.annotation:annotation:1.1.0'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }


### PR DESCRIPTION
## What this does

Migrates the Android plugin to AGP 9's built-in Kotlin while keeping older toolchains building:

- Apply the **Kotlin Gradle Plugin only when built-in Kotlin is inactive** — AGP < 9, or AGP 9 with `android.builtInKotlin=false`. When AGP 9's built-in Kotlin is active it registers the `kotlin` extension itself and rejects KGP, so applying it is skipped.
- Set the JVM target through the `kotlin { compilerOptions {} }` DSL **when the extension supports it** (KGP 1.9+ / AGP 9 built-in Kotlin), falling back to the legacy `kotlinOptions` DSL otherwise.
- Bump the standalone buildscript fallbacks (AGP 7.1.1 → 8.1.0, KGP 1.8.10 → 2.1.0) so they're self-consistent.
- Drop the explicit `kotlin-stdlib-jdk7` dependency; KGP and AGP 9 built-in Kotlin add the standard library automatically.

## Why the conditional logic

The plugin is consumed by apps across a wide range of Flutter / AGP / Kotlin versions, so two compatibility points shape the config:

- **Kotlin Gradle Plugin version.** The `kotlin { compilerOptions {} }` DSL requires KGP 1.9+ — `KotlinAndroidProjectExtension.compilerOptions` doesn't exist before then. Flutter app templates before 3.29 still declare Kotlin 1.8.22, so the plugin feature-detects `compilerOptions` and falls back to `kotlinOptions`. Without that fallback, those apps fail at configuration with:
  ```
  > Could not find method compilerOptions() for arguments [...] on extension 'kotlin'
  ```
- **`android.builtInKotlin` flag.** Flutter currently ships AGP 9 with `android.builtInKotlin=false` by default (flutter/flutter#183910) — built-in Kotlin off, KGP still required. Gating on the AGP major version alone would skip `kotlin-android` there and leave the module with no `kotlin` extension:
  ```
  > Extension with name 'kotlin' does not exist.
  ```
  So the plugin gates on whether built-in Kotlin is *actually active* (`agpMajor >= 9 && android.builtInKotlin != false`).

## Testing

`flutter build apk --debug`, plugin consumed by an example / probe app:

| Flutter | App toolchain | Path exercised | Result |
|---|---|---|---|
| 3.44.1 | AGP 8.6.0, KGP 2.1.0 | `compilerOptions` DSL | ✅ |
| 3.41.6 | AGP 8.6.0, KGP 1.8.22 | `kotlinOptions` fallback | ✅ |
| 3.44.1 | AGP 9.0.1, `builtInKotlin=false` (template default) | applies KGP | ✅ |
| 3.41.6 | KGP 1.8.22, unguarded `compilerOptions` (control) | — | ❌ — confirms the fallback is needed |
| 3.44.1 | AGP 9.0.1 `builtInKotlin=false`, AGP-version-only gate (control) | — | ❌ — confirms the `builtInKotlin` gate is needed |

Built-in-Kotlin-*active* (`android.builtInKotlin=true`) is not reachable on shipping Flutter yet: Flutter 3.44.1's Gradle plugin auto-applies `kotlin-android` to Kotlin-source modules, which collides with it. For that future path the gate skips KGP and the `kotlin { compilerOptions {} }` DSL drives the JVM target.

Supersedes #2063. Fixes #2053, closes #2056.
