### PR TITLE
fix(desktop): resolve remote tracks by id so setVolume reaches them

### DIFF
--- a/common/cpp/include/flutter_peerconnection.h
+++ b/common/cpp/include/flutter_peerconnection.h
@@ -42,6 +42,11 @@ class FlutterPeerConnectionObserver : public RTCPeerConnectionObserver {
   std::unique_ptr<EventChannelProxy> event_channel_;
   scoped_refptr<RTCPeerConnection> peerconnection_;
   std::map<std::string, scoped_refptr<RTCMediaStream>> remote_streams_;
+  // Remote tracks indexed by id. `remote_streams_` is only populated by
+  // OnAddStream, which never fires under Unified Plan, so it cannot be used to
+  // resolve receiver tracks. Entries are dropped in OnRemoveTrack and, at the
+  // latest, when this observer is destroyed with the peer connection.
+  std::map<std::string, scoped_refptr<RTCMediaTrack>> remote_tracks_;
   FlutterWebRTCBase* base_;
   std::string id_;
 };

--- a/common/cpp/src/flutter_peerconnection.cc
+++ b/common/cpp/src/flutter_peerconnection.cc
@@ -1343,6 +1343,9 @@ void FlutterPeerConnectionObserver::OnAddTrack(
     vector<scoped_refptr<RTCMediaStream>> streams,
     scoped_refptr<RTCRtpReceiver> receiver) {
   auto track = receiver->track();
+  if (track.get()) {
+    remote_tracks_[track->id().std_string()] = track;
+  }
 
   std::vector<scoped_refptr<RTCMediaStream>> mediaStreams;
   for (scoped_refptr<RTCMediaStream> stream : streams.std_vector()) {
@@ -1372,6 +1375,10 @@ void FlutterPeerConnectionObserver::OnAddTrack(
 void FlutterPeerConnectionObserver::OnTrack(
     scoped_refptr<RTCRtpTransceiver> transceiver) {
   auto receiver = transceiver->receiver();
+  auto track = receiver->track();
+  if (track.get()) {
+    remote_tracks_[track->id().std_string()] = track;
+  }
   EncodableMap params;
   EncodableList streams_info;
   auto streams = receiver->streams();
@@ -1393,6 +1400,9 @@ void FlutterPeerConnectionObserver::OnTrack(
 void FlutterPeerConnectionObserver::OnRemoveTrack(
     scoped_refptr<RTCRtpReceiver> receiver) {
   auto track = receiver->track();
+  if (track.get()) {
+    remote_tracks_.erase(track->id().std_string());
+  }
 
   EncodableMap params;
   params[EncodableValue("event")] = "onRemoveTrack";
@@ -1467,6 +1477,10 @@ scoped_refptr<RTCMediaStream> FlutterPeerConnectionObserver::MediaStreamForId(
 
 scoped_refptr<RTCMediaTrack> FlutterPeerConnectionObserver::MediaTrackForId(
     const std::string& id) {
+  auto known = remote_tracks_.find(id);
+  if (known != remote_tracks_.end())
+    return (*known).second;
+
   for (auto it = remote_streams_.begin(); it != remote_streams_.end(); it++) {
     auto remoteStream = (*it).second;
     auto audio_tracks = remoteStream->audio_tracks();


### PR DESCRIPTION
## Problem

On desktop (Windows/Linux), `Helper.setVolume(volume, track)` on a **remote** audio track
always fails with:

```
setVolume() Unable to find provided track
```

The lookup is `FlutterWebRTCBase::MediaTrackForId`, which checks `local_tracks_` and then
asks each `FlutterPeerConnectionObserver`. The observer resolves ids by scanning
`remote_streams_` — and `remote_streams_` is filled **only** in `OnAddStream`, a Plan B
callback. Under Unified Plan (what `livekit_client` and most current apps use), remote
tracks arrive through `OnTrack`/`OnAddTrack`, and neither of them registers the track
anywhere. So no remote track is ever resolvable by id on desktop.

The consequence for apps is that per-participant volume is silently a no-op: the error is
returned to Dart, and callers that guard the call (most do, since the same call throws on
platforms where the plugin is absent) swallow it. Related reports:
livekit/client-sdk-flutter#235 and livekit/client-sdk-flutter#707.

Worth noting the mechanism underneath is already complete — `RemoteAudioSource` implements
`SetVolume` and forwards it to the receiver through `OnSetVolume`, in the documented
`[0, 10]` range. Only the id lookup is missing.

## Change

Keep the receiver's track in a `remote_tracks_` map keyed by id:

* filled in both `OnAddTrack` and `OnTrack` (the registration in `OnAddTrack` is outside
  the stream loop, since the stream list can be empty);
* dropped in `OnRemoveTrack`;
* consulted by `MediaTrackForId` **before** the existing `remote_streams_` scan, so Plan B
  behaviour is unchanged.

19 lines added, nothing removed.

### Lifetime

References are released in `OnRemoveTrack` and, at the latest, when the observer is
destroyed with the peer connection — the same lifetime `remote_streams_` already has, so
this does not introduce a new class of retention.

## Testing

* `clang++ -fsyntax-only` over `flutter_peerconnection.cc` against the m144 headers and the
  Flutter C++ client wrapper, on both `main` and the `v1.6.0` tag; a deliberately broken
  call was used as a control to confirm the check actually fails.
* Not yet exercised at runtime on Windows — we are about to ship it in a small app that
  needs per-participant volume, and I will report back here with the result. Happy to hold
  the PR until then if you prefer.