### PR TITLE
feat(android,ios): add native picture-in-picture support

### DIFF
--- a/Documentation/PICTURE_IN_PICTURE.md
+++ b/Documentation/PICTURE_IN_PICTURE.md
@@ -1,0 +1,145 @@
+# Picture in Picture
+
+`RTCPictureInPictureController` drives the native picture-in-picture window on
+Android 8+ and iOS 15+. The two platforms behave differently:
+
+- **Android** shrinks the whole activity. Flutter keeps rendering inside the
+  small window, so the app is expected to switch to a reduced layout (usually
+  just the remote video) while picture-in-picture is active.
+- **iOS** shows a native view that renders a single video track. The Flutter UI
+  is not visible while picture-in-picture is active.
+
+## Usage
+
+```dart
+final pip = RTCPictureInPictureController();
+final videoKey = GlobalKey();
+
+// After the remote stream is attached to a renderer:
+await pip.configure(
+  stream: remoteStream,
+  sourceRect: RTCPictureInPictureController.globalRectOf(videoKey),
+  aspectRatio: remoteRenderer.value.aspectRatio,
+);
+
+// Enter explicitly (for example from a button). With autoEnter (the default)
+// the system also enters when the app goes to the background.
+await pip.start();
+
+// Rebuild with a reduced layout while active.
+RTCPictureInPictureBuilder(
+  controller: pip,
+  builder: (context, isInPictureInPicture, child) =>
+      isInPictureInPicture ? child! : fullLayout(child!),
+  child: RTCVideoView(remoteRenderer, key: videoKey),
+);
+
+// State changes.
+pip.events.listen((event) => print(event.state));
+
+// When the call ends.
+await pip.dispose();
+```
+
+`configure` can be called again at any time to switch the video track, update
+the source rect after a layout change, or change the aspect ratio.
+
+Check `RTCPictureInPictureController.isSupported()` before showing a
+picture-in-picture button. It returns `false` on web, desktop, Android below
+8, iOS below 15 and on the iOS simulator.
+
+## Android setup
+
+Declare picture-in-picture support on the activity in
+`android/app/src/main/AndroidManifest.xml`:
+
+```xml
+<activity
+    android:name=".MainActivity"
+    android:supportsPictureInPicture="true"
+    android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|screenLayout|density|uiMode"
+    ...>
+```
+
+Without `android:supportsPictureInPicture` `start()` returns `false`.
+
+On Android 12 and newer, `autoEnter` works without additional code. On
+Android 8 to 11 the system only allows entering picture-in-picture from
+`Activity.onUserLeaveHint`, which plugins cannot observe, so forward it from
+your `MainActivity`:
+
+```java
+import android.content.res.Configuration;
+import androidx.annotation.NonNull;
+import com.cloudwebrtc.webrtc.FlutterWebRTCPlugin;
+import io.flutter.embedding.android.FlutterActivity;
+
+public class MainActivity extends FlutterActivity {
+    @Override
+    public void onUserLeaveHint() {
+        super.onUserLeaveHint();
+        FlutterWebRTCPlugin.onUserLeaveHint();
+    }
+
+    @Override
+    public void onPictureInPictureModeChanged(boolean isInPictureInPictureMode,
+                                              @NonNull Configuration newConfig) {
+        super.onPictureInPictureModeChanged(isInPictureInPictureMode, newConfig);
+        FlutterWebRTCPlugin.onPictureInPictureModeChanged(isInPictureInPictureMode);
+    }
+}
+```
+
+Forwarding `onPictureInPictureModeChanged` is optional: the plugin also detects
+the transition from the activity lifecycle.
+
+Camera and microphone keep working while the activity is in
+picture-in-picture.
+
+## iOS setup
+
+Add the `audio` background mode to `ios/Runner/Info.plist`, otherwise the
+process is suspended when the app leaves the foreground and the video freezes:
+
+```xml
+<key>UIBackgroundModes</key>
+<array>
+    <string>audio</string>
+</array>
+```
+
+Picture-in-picture uses the video-call content source, so it requires iOS 15
+and a physical device.
+
+### Camera in the background
+
+iOS interrupts the camera when the app goes to the background, so a local
+camera track stops producing frames while remote tracks keep rendering. Apps
+granted the `com.apple.developer.avfoundation.multitasking-camera-access`
+entitlement can keep the camera running on iOS 16+ by enabling it before the
+first `getUserMedia`:
+
+```dart
+await WebRTC.initialize(options: {'multitaskingCameraAccess': true});
+```
+
+### Using a platform view as the animation source
+
+When the video is shown with `RTCVideoPlatFormView`, pass its controller's
+`textureId` as `platformViewId` so the system animates from that view instead
+of `sourceRect`:
+
+```dart
+await pip.configure(stream: remoteStream, platformViewId: controller.textureId);
+```
+
+## Events
+
+| State | Android | iOS |
+|---|---|---|
+| `willStart` | | ✔ |
+| `started` | ✔ | ✔ |
+| `willStop` | | ✔ |
+| `stopped` | ✔ | ✔ |
+| `failed` | | ✔ (`error` describes the failure) |
+| `restoreUserInterface` | | ✔ (the user tapped the restore button) |

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Enterprise Grade APIs for Feeds, Chat, & Video. <a href="https://getstream.io/vi
 | Simulcast | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | |
 | MediaRecorder | :warning: | :warning: | :heavy_check_mark: | | | | | |
 | End to End Encryption | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | |
+| Picture in Picture | :heavy_check_mark: | :heavy_check_mark: | | | | | | |
 | Insertable Streams | | | | | | | | |
 
 Additional platform/OS support from the other community
@@ -121,6 +122,10 @@ If necessary, in the same `build.gradle` you will need to increase `minSdkVersio
 
 When you compile the release apk, you need to add the following operations,
 [Setup Proguard Rules](https://github.com/flutter-webrtc/flutter-webrtc/blob/main/android/proguard-rules.pro)
+
+### Picture in Picture
+
+`RTCPictureInPictureController` drives native picture-in-picture on Android 8+ and iOS 15+. Setup steps for each platform are in [Documentation/PICTURE_IN_PICTURE.md](Documentation/PICTURE_IN_PICTURE.md).
 
 ## Contributing
 

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="com.cloudwebrtc.webrtc">
+  <uses-feature android:name="android.software.picture_in_picture" android:required="false" />
 </manifest>

--- a/android/src/main/java/com/cloudwebrtc/webrtc/FlutterWebRTCPlugin.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/FlutterWebRTCPlugin.java
@@ -86,6 +86,28 @@ public class FlutterWebRTCPlugin implements FlutterPlugin, ActivityAware, EventC
         return methodCallHandler == null ? null : methodCallHandler.getAudioDeviceModule();
     }
 
+    // Forward from Activity#onUserLeaveHint to auto-enter picture-in-picture on Android 8-11.
+    public static void onUserLeaveHint() {
+        if (sharedSingleton != null && sharedSingleton.methodCallHandler != null) {
+            sharedSingleton.methodCallHandler.getPictureInPictureManager().onUserLeaveHint();
+        }
+    }
+
+    // Forward from Activity#onPictureInPictureModeChanged. Optional: the lifecycle
+    // observer below also detects the transition.
+    public static void onPictureInPictureModeChanged(boolean isInPictureInPictureMode) {
+        if (sharedSingleton != null && sharedSingleton.methodCallHandler != null) {
+            sharedSingleton.methodCallHandler.getPictureInPictureManager()
+                    .onPictureInPictureModeChanged(isInPictureInPictureMode);
+        }
+    }
+
+    private void syncPictureInPictureState() {
+        if (methodCallHandler != null) {
+            methodCallHandler.getPictureInPictureManager().syncState();
+        }
+    }
+
     @Override
     public void onAttachedToEngine(@NonNull FlutterPluginBinding binding) {
         startListening(binding.getApplicationContext(), binding.getBinaryMessenger(),
@@ -194,6 +216,17 @@ public class FlutterWebRTCPlugin implements FlutterPlugin, ActivityAware, EventC
             if (null != methodCallHandler) {
                 methodCallHandler.reStartCamera();
             }
+            syncPictureInPictureState();
+        }
+
+        @Override
+        public void onPause(LifecycleOwner owner) {
+            syncPictureInPictureState();
+        }
+
+        @Override
+        public void onStop(LifecycleOwner owner) {
+            syncPictureInPictureState();
         }
 
         @Override

--- a/android/src/main/java/com/cloudwebrtc/webrtc/MethodCallHandlerImpl.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/MethodCallHandlerImpl.java
@@ -30,6 +30,7 @@ import com.cloudwebrtc.webrtc.audio.AudioUtils;
 import com.cloudwebrtc.webrtc.audio.LocalAudioTrack;
 import com.cloudwebrtc.webrtc.audio.PlaybackSamplesReadyCallbackAdapter;
 import com.cloudwebrtc.webrtc.audio.RecordSamplesReadyCallbackAdapter;
+import com.cloudwebrtc.webrtc.pip.PictureInPictureManager;
 import com.cloudwebrtc.webrtc.record.AudioChannel;
 import com.cloudwebrtc.webrtc.record.FrameCapturer;
 import com.cloudwebrtc.webrtc.utils.AnyThreadResult;
@@ -161,10 +162,21 @@ public class MethodCallHandlerImpl implements MethodCallHandler, StateProvider {
 
   public static LogSink logSink = new LogSink();
 
+  private final PictureInPictureManager pictureInPictureManager;
+
   MethodCallHandlerImpl(Context context, BinaryMessenger messenger, TextureRegistry textureRegistry) {
     this.context = context;
     this.textures = textureRegistry;
     this.messenger = messenger;
+    this.pictureInPictureManager = new PictureInPictureManager(this, event -> {
+      if (FlutterWebRTCPlugin.sharedSingleton != null) {
+        FlutterWebRTCPlugin.sharedSingleton.sendEvent(event);
+      }
+    });
+  }
+
+  public PictureInPictureManager getPictureInPictureManager() {
+    return pictureInPictureManager;
   }
 
   static private void resultError(String method, String error, Result result) {
@@ -174,6 +186,7 @@ public class MethodCallHandlerImpl implements MethodCallHandler, StateProvider {
   }
 
   void dispose() {
+    pictureInPictureManager.dispose();
     for (final MediaStream mediaStream : localStreams.values()) {
       try {
         streamDispose(mediaStream);
@@ -751,6 +764,33 @@ public class MethodCallHandlerImpl implements MethodCallHandler, StateProvider {
         } else {
           render.setStream(stream, ownerTag);
         }
+        result.success(null);
+        break;
+      }
+      case "pipIsSupported": {
+        result.success(pictureInPictureManager.isSupported());
+        break;
+      }
+      case "pipConfigure": {
+        Map<String, Object> args = call.arguments();
+        pictureInPictureManager.configure(new ConstraintsMap(args));
+        result.success(null);
+        break;
+      }
+      case "pipStart": {
+        result.success(pictureInPictureManager.enter());
+        break;
+      }
+      case "pipStop": {
+        result.success(null);
+        break;
+      }
+      case "pipIsActive": {
+        result.success(pictureInPictureManager.isActive());
+        break;
+      }
+      case "pipDispose": {
+        pictureInPictureManager.dispose();
         result.success(null);
         break;
       }

--- a/android/src/main/java/com/cloudwebrtc/webrtc/pip/PictureInPictureManager.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/pip/PictureInPictureManager.java
@@ -1,0 +1,163 @@
+package com.cloudwebrtc.webrtc.pip;
+
+import android.app.Activity;
+import android.app.PictureInPictureParams;
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.graphics.Rect;
+import android.os.Build;
+import android.util.Log;
+import android.util.Rational;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
+
+import com.cloudwebrtc.webrtc.FlutterWebRTCPlugin;
+import com.cloudwebrtc.webrtc.StateProvider;
+import com.cloudwebrtc.webrtc.utils.ConstraintsMap;
+import com.cloudwebrtc.webrtc.utils.ObjectType;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class PictureInPictureManager {
+  private static final String TAG = FlutterWebRTCPlugin.TAG;
+
+  // Limits enforced by PictureInPictureParams.Builder#setAspectRatio.
+  private static final double MIN_ASPECT_RATIO = 1.0 / 2.39;
+  private static final double MAX_ASPECT_RATIO = 2.39;
+
+  public interface EventSink {
+    void send(Map<String, Object> event);
+  }
+
+  private final StateProvider stateProvider;
+  private final EventSink eventSink;
+
+  private Rational aspectRatio;
+  private Rect sourceRect;
+  private boolean autoEnter;
+  private boolean seamlessResize = true;
+  private boolean configured;
+  private boolean inPictureInPicture;
+
+  public PictureInPictureManager(@NonNull StateProvider stateProvider, @NonNull EventSink eventSink) {
+    this.stateProvider = stateProvider;
+    this.eventSink = eventSink;
+  }
+
+  public boolean isSupported() {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+      return false;
+    }
+    Context context = stateProvider.getApplicationContext();
+    return context != null
+        && context.getPackageManager().hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE);
+  }
+
+  public void configure(ConstraintsMap args) {
+    aspectRatio = null;
+    if (args.hasKey("aspectRatio") && args.getType("aspectRatio") == ObjectType.Number) {
+      double ratio = Math.max(MIN_ASPECT_RATIO, Math.min(MAX_ASPECT_RATIO, args.getDouble("aspectRatio")));
+      aspectRatio = new Rational((int) Math.round(ratio * 1000), 1000);
+    }
+
+    sourceRect = null;
+    if (args.hasKey("sourceRect") && args.getType("sourceRect") == ObjectType.Map) {
+      ConstraintsMap rect = args.getMap("sourceRect");
+      double scale = 1.0;
+      if (args.hasKey("devicePixelRatio") && args.getType("devicePixelRatio") == ObjectType.Number) {
+        scale = args.getDouble("devicePixelRatio");
+      }
+      sourceRect = new Rect(
+          (int) Math.round(rect.getDouble("left") * scale),
+          (int) Math.round(rect.getDouble("top") * scale),
+          (int) Math.round(rect.getDouble("right") * scale),
+          (int) Math.round(rect.getDouble("bottom") * scale));
+    }
+
+    autoEnter = args.hasKey("autoEnter") && args.getBoolean("autoEnter");
+    seamlessResize = !args.hasKey("seamlessResize") || args.getBoolean("seamlessResize");
+    configured = true;
+    applyParams();
+  }
+
+  public boolean enter() {
+    Activity activity = stateProvider.getActivity();
+    if (activity == null || !isSupported()) {
+      return false;
+    }
+    try {
+      return activity.enterPictureInPictureMode(buildParams());
+    } catch (IllegalStateException | IllegalArgumentException e) {
+      Log.w(TAG, "enterPictureInPictureMode failed", e);
+      return false;
+    }
+  }
+
+  public boolean isActive() {
+    Activity activity = stateProvider.getActivity();
+    return Build.VERSION.SDK_INT >= Build.VERSION_CODES.N
+        && activity != null
+        && activity.isInPictureInPictureMode();
+  }
+
+  // Android 12+ enters automatically through setAutoEnterEnabled; older
+  // versions only allow entering from Activity#onUserLeaveHint.
+  public void onUserLeaveHint() {
+    if (configured && autoEnter && Build.VERSION.SDK_INT < Build.VERSION_CODES.S && !isActive()) {
+      enter();
+    }
+  }
+
+  public void onPictureInPictureModeChanged(boolean isInPictureInPictureMode) {
+    if (inPictureInPicture == isInPictureInPictureMode) {
+      return;
+    }
+    inPictureInPicture = isInPictureInPictureMode;
+    Map<String, Object> event = new HashMap<>();
+    event.put("event", "pictureInPictureStateChanged");
+    event.put("state", isInPictureInPictureMode ? "started" : "stopped");
+    eventSink.send(event);
+  }
+
+  public void syncState() {
+    onPictureInPictureModeChanged(isActive());
+  }
+
+  public void dispose() {
+    configured = false;
+    autoEnter = false;
+    aspectRatio = null;
+    sourceRect = null;
+    applyParams();
+  }
+
+  private void applyParams() {
+    Activity activity = stateProvider.getActivity();
+    if (activity == null || !isSupported()) {
+      return;
+    }
+    try {
+      activity.setPictureInPictureParams(buildParams());
+    } catch (IllegalStateException | IllegalArgumentException e) {
+      Log.w(TAG, "setPictureInPictureParams failed", e);
+    }
+  }
+
+  @RequiresApi(Build.VERSION_CODES.O)
+  private PictureInPictureParams buildParams() {
+    PictureInPictureParams.Builder builder = new PictureInPictureParams.Builder();
+    if (aspectRatio != null) {
+      builder.setAspectRatio(aspectRatio);
+    }
+    if (sourceRect != null) {
+      builder.setSourceRectHint(sourceRect);
+    }
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+      builder.setAutoEnterEnabled(autoEnter);
+      builder.setSeamlessResizeEnabled(seamlessResize);
+    }
+    return builder.build();
+  }
+}

--- a/common/darwin/Classes/FlutterRTCMediaStream.m
+++ b/common/darwin/Classes/FlutterRTCMediaStream.m
@@ -488,7 +488,19 @@ typedef void (^NavigatorUserMediaSuccessCallback)(RTCMediaStream* mediaStream);
       
     VideoProcessingAdapter *videoProcessingAdapter = [[VideoProcessingAdapter alloc] initWithRTCVideoSource:videoSource];
     self.videoCapturer = [[RTCCameraVideoCapturer alloc] initWithDelegate:videoProcessingAdapter];
-      
+#if TARGET_OS_IPHONE
+    if (self.multitaskingCameraAccess) {
+      if (@available(iOS 16.0, *)) {
+        AVCaptureSession* captureSession = self.videoCapturer.captureSession;
+        if (captureSession.isMultitaskingCameraAccessSupported) {
+          [captureSession beginConfiguration];
+          captureSession.multitaskingCameraAccessEnabled = YES;
+          [captureSession commitConfiguration];
+        }
+      }
+    }
+#endif
+
     AVCaptureDeviceFormat* selectedFormat = [self selectFormatForDevice:videoDevice
                                                             targetWidth:targetWidth
                                                            targetHeight:targetHeight];

--- a/common/darwin/Classes/FlutterRTCVideoPlatformView.h
+++ b/common/darwin/Classes/FlutterRTCVideoPlatformView.h
@@ -5,6 +5,8 @@
 
 @interface FlutterRTCVideoPlatformView : FlutterRTCVideoPlatformNativeView
 
+@property(nonatomic, copy, nonnull) AVLayerVideoGravity videoGravity;
+
 - (void)renderFrame:(nullable RTC_OBJC_TYPE(RTCVideoFrame) *)frame;
 
 - (instancetype _Nonnull)initWithFrame:(FlutterRTCVideoPlatformFrame)frame;

--- a/common/darwin/Classes/FlutterRTCVideoPlatformView.m
+++ b/common/darwin/Classes/FlutterRTCVideoPlatformView.m
@@ -63,6 +63,14 @@
   [_videoLayer removeAllAnimations];
 }
 
+- (AVLayerVideoGravity)videoGravity {
+  return _videoLayer.videoGravity;
+}
+
+- (void)setVideoGravity:(AVLayerVideoGravity)videoGravity {
+  _videoLayer.videoGravity = videoGravity;
+}
+
 - (void)setSize:(CGSize)size {
 }
 

--- a/common/darwin/Classes/FlutterWebRTCPlugin.h
+++ b/common/darwin/Classes/FlutterWebRTCPlugin.h
@@ -52,6 +52,10 @@ typedef void (^CapturerStopHandler)(CompletionHandler _Nonnull handler);
 #if TARGET_OS_IPHONE
 @property(nonatomic, retain)
     UIViewController* _Nullable viewController; /*for broadcast or ReplayKit */
+/// Enables AVCaptureSession.multitaskingCameraAccessEnabled on iOS 16+ so the
+/// camera keeps running in the background. Requires the
+/// com.apple.developer.avfoundation.multitasking-camera-access entitlement.
+@property(nonatomic) BOOL multitaskingCameraAccess;
 #endif
 
 @property(nonatomic, strong) FlutterEventSink _Nullable eventSink;

--- a/common/darwin/Classes/FlutterWebRTCPlugin.m
+++ b/common/darwin/Classes/FlutterWebRTCPlugin.m
@@ -11,6 +11,7 @@
 #import "FlutterRTCFrameCryptor.h"
 #if TARGET_OS_IPHONE
 #import "FlutterRTCMediaRecorder.h"
+#import "FlutterRTCPictureInPictureController.h"
 #endif
 #if TARGET_OS_IPHONE || TARGET_OS_OSX
 #import "FlutterRTCVideoPlatformViewFactory.h"
@@ -121,6 +122,9 @@ void postEvent(FlutterEventSink _Nullable sink, id _Nullable event) {
   AudioManager* _audioManager;
 #if TARGET_OS_IPHONE || TARGET_OS_OSX
   FlutterRTCVideoPlatformViewFactory *_platformViewFactory;
+#endif
+#if TARGET_OS_IPHONE
+  FlutterRTCPictureInPictureController* _pipController API_AVAILABLE(ios(15.0));
 #endif
 
   RTC_OBJC_TYPE(RTCCallbackLogger) * loggerCallback;
@@ -273,6 +277,12 @@ static __weak id<RTCAudioDeviceModuleDelegate> gAudioDeviceModuleObserver = nil;
 }
 
 - (void)detachFromEngineForRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
+#if TARGET_OS_IPHONE
+  if (@available(iOS 15.0, *)) {
+    [_pipController dispose];
+    _pipController = nil;
+  }
+#endif
   for (RTCPeerConnection* peerConnection in _peerConnections.allValues) {
     for (RTCDataChannel* dataChannel in peerConnection.dataChannels) {
       dataChannel.eventSink = nil;
@@ -431,6 +441,122 @@ static __weak id<RTCAudioDeviceModuleDelegate> gAudioDeviceModuleObserver = nil;
     }
 }
 
+- (RTCVideoTrack*)videoTrackForStreamId:(NSString*)streamId
+                               ownerTag:(NSString*)ownerTag
+                                trackId:(NSString*)trackId {
+  RTCMediaStream* stream = nil;
+  if ([ownerTag isEqualToString:@"local"]) {
+    stream = _localStreams[streamId];
+  }
+  if (!stream) {
+    stream = [self streamForId:streamId peerConnectionId:ownerTag];
+  }
+  if (!stream) {
+    return nil;
+  }
+  NSArray* videoTracks = stream.videoTracks;
+  RTCVideoTrack* videoTrack = videoTracks.count ? videoTracks[0] : nil;
+  for (RTCVideoTrack* track in videoTracks) {
+    if ([track.trackId isEqualToString:trackId]) {
+      videoTrack = track;
+    }
+  }
+  if (!videoTrack) {
+    NSLog(@"Not found video track for RTCMediaStream: %@", streamId);
+  }
+  return videoTrack;
+}
+
+#if TARGET_OS_IPHONE
+- (UIView*)flutterRootView {
+  UIWindow* window = nil;
+  for (UIScene* scene in UIApplication.sharedApplication.connectedScenes) {
+    if (![scene isKindOfClass:[UIWindowScene class]]) {
+      continue;
+    }
+    UIWindowScene* windowScene = (UIWindowScene*)scene;
+    UIWindow* candidate = nil;
+    for (UIWindow* sceneWindow in windowScene.windows) {
+      if (sceneWindow.isKeyWindow) {
+        candidate = sceneWindow;
+        break;
+      }
+    }
+    if (!candidate) {
+      candidate = windowScene.windows.firstObject;
+    }
+    if (!candidate) {
+      continue;
+    }
+    BOOL foreground = windowScene.activationState == UISceneActivationStateForegroundActive;
+    if (window == nil || foreground) {
+      window = candidate;
+    }
+    if (foreground) {
+      break;
+    }
+  }
+  if (!window) {
+    window = UIApplication.sharedApplication.delegate.window;
+  }
+  return window.rootViewController.view;
+}
+
+- (void)pipConfigure:(NSDictionary*)argsMap API_AVAILABLE(ios(15.0)) {
+  if (!_pipController) {
+    _pipController = [[FlutterRTCPictureInPictureController alloc] init];
+    __weak FlutterWebRTCPlugin* weakSelf = self;
+    _pipController.stateHandler = ^(NSString* state, NSString* error) {
+      FlutterWebRTCPlugin* strongSelf = weakSelf;
+      if (!strongSelf) {
+        return;
+      }
+      postEvent(strongSelf.eventSink, @{
+        @"event" : @"pictureInPictureStateChanged",
+        @"state" : state,
+        @"error" : error ?: [NSNull null],
+      });
+    };
+  }
+
+  NSString* streamId = argsMap[@"streamId"];
+  if ([streamId isKindOfClass:[NSString class]] && streamId.length > 0) {
+    _pipController.videoTrack = [self videoTrackForStreamId:streamId
+                                                   ownerTag:argsMap[@"ownerTag"]
+                                                    trackId:argsMap[@"trackId"]];
+  }
+
+  UIView* sourceView = nil;
+  NSNumber* platformViewId = argsMap[@"platformViewId"];
+  if ([platformViewId isKindOfClass:[NSNumber class]]) {
+    sourceView = [_platformViewFactory.renders[platformViewId] view];
+  }
+  if (!sourceView) {
+    UIView* rootView = [self flutterRootView];
+    CGRect frame = rootView.bounds;
+    NSDictionary* rect = argsMap[@"sourceRect"];
+    if ([rect isKindOfClass:[NSDictionary class]]) {
+      double left = [rect[@"left"] doubleValue];
+      double top = [rect[@"top"] doubleValue];
+      frame = CGRectMake(left, top, [rect[@"right"] doubleValue] - left,
+                         [rect[@"bottom"] doubleValue] - top);
+    }
+    sourceView = [_pipController anchorViewInView:rootView frame:frame];
+  }
+
+  NSNumber* aspectRatio = argsMap[@"aspectRatio"];
+  AVLayerVideoGravity gravity = [argsMap[@"objectFit"] isEqual:@"cover"]
+                                    ? AVLayerVideoGravityResizeAspectFill
+                                    : AVLayerVideoGravityResizeAspect;
+  [_pipController configureWithSourceView:sourceView
+                              aspectRatio:[aspectRatio isKindOfClass:[NSNumber class]]
+                                              ? aspectRatio.doubleValue
+                                              : 0
+                                autoEnter:[argsMap[@"autoEnter"] boolValue]
+                             videoGravity:gravity];
+}
+#endif
+
 - (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result {
   if ([@"initialize" isEqualToString:call.method]) {
     NSDictionary* argsMap = call.arguments;
@@ -448,6 +574,11 @@ static __weak id<RTCAudioDeviceModuleDelegate> gAudioDeviceModuleObserver = nil;
       NSString* severityStr = ((NSString*)options[@"logSeverity"]);
       severity = [self str2LogSeverity:severityStr];
     }
+#if TARGET_OS_IPHONE
+    if (options[@"multitaskingCameraAccess"] != nil) {
+      self.multitaskingCameraAccess = ((NSNumber*)options[@"multitaskingCameraAccess"]).boolValue;
+    }
+#endif
 
     [self initialize:networkIgnoreMask bypassVoiceProcessing:enableBypassVoiceProcessing
                      severity:severity];
@@ -951,26 +1082,9 @@ static __weak id<RTCAudioDeviceModuleDelegate> gAudioDeviceModuleObserver = nil;
                                  details:nil]);
       return;
     }
-    RTCMediaStream* stream = nil;
-    RTCVideoTrack* videoTrack = nil;
-    if ([ownerTag isEqualToString:@"local"]) {
-      stream = _localStreams[streamId];
-    }
-    if (!stream) {
-      stream = [self streamForId:streamId peerConnectionId:ownerTag];
-    }
-    if (stream) {
-      NSArray* videoTracks = stream ? stream.videoTracks : nil;
-      videoTrack = videoTracks && videoTracks.count ? videoTracks[0] : nil;
-      for (RTCVideoTrack* track in videoTracks) {
-        if ([track.trackId isEqualToString:trackId]) {
-          videoTrack = track;
-        }
-      }
-      if (!videoTrack) {
-        NSLog(@"Not found video track for RTCMediaStream: %@", streamId);
-      }
-    }
+    RTCVideoTrack* videoTrack = [self videoTrackForStreamId:streamId
+                                                   ownerTag:ownerTag
+                                                    trackId:trackId];
     [self rendererSetSrcObject:render stream:videoTrack];
     result(nil);
   }
@@ -988,27 +1102,7 @@ static __weak id<RTCAudioDeviceModuleDelegate> gAudioDeviceModuleObserver = nil;
                                    details:nil]);
         return;
       }
-      RTCMediaStream* stream = nil;
-      RTCVideoTrack* videoTrack = nil;
-      if ([ownerTag isEqualToString:@"local"]) {
-        stream = _localStreams[streamId];
-      }
-      if (!stream) {
-        stream = [self streamForId:streamId peerConnectionId:ownerTag];
-      }
-      if (stream) {
-        NSArray* videoTracks = stream ? stream.videoTracks : nil;
-        videoTrack = videoTracks && videoTracks.count ? videoTracks[0] : nil;
-        for (RTCVideoTrack* track in videoTracks) {
-          if ([track.trackId isEqualToString:trackId]) {
-            videoTrack = track;
-          }
-        }
-        if (!videoTrack) {
-          NSLog(@"Not found video track for RTCMediaStream: %@", streamId);
-        }
-      }
-      render.videoTrack = videoTrack;
+      render.videoTrack = [self videoTrackForStreamId:streamId ownerTag:ownerTag trackId:trackId];
       result(nil);
   } else if ([@"videoPlatformViewRendererDispose" isEqualToString:call.method]) {
       NSDictionary* argsMap = call.arguments;
@@ -1020,6 +1114,47 @@ static __weak id<RTCAudioDeviceModuleDelegate> gAudioDeviceModuleObserver = nil;
       }
       result(nil);
     }
+#endif
+#if TARGET_OS_IPHONE
+  else if ([@"pipIsSupported" isEqualToString:call.method]) {
+    BOOL supported = NO;
+    if (@available(iOS 15.0, *)) {
+      supported = [FlutterRTCPictureInPictureController isSupported];
+    }
+    result(@(supported));
+  } else if ([@"pipConfigure" isEqualToString:call.method]) {
+    if (@available(iOS 15.0, *)) {
+      [self pipConfigure:call.arguments];
+      result(nil);
+    } else {
+      result([FlutterError errorWithCode:@"pipUnsupported"
+                                 message:@"Picture in picture requires iOS 15 or newer"
+                                 details:nil]);
+    }
+  } else if ([@"pipStart" isEqualToString:call.method]) {
+    BOOL started = NO;
+    if (@available(iOS 15.0, *)) {
+      started = [_pipController start];
+    }
+    result(@(started));
+  } else if ([@"pipStop" isEqualToString:call.method]) {
+    if (@available(iOS 15.0, *)) {
+      [_pipController stop];
+    }
+    result(nil);
+  } else if ([@"pipIsActive" isEqualToString:call.method]) {
+    BOOL active = NO;
+    if (@available(iOS 15.0, *)) {
+      active = [_pipController isActive];
+    }
+    result(@(active));
+  } else if ([@"pipDispose" isEqualToString:call.method]) {
+    if (@available(iOS 15.0, *)) {
+      [_pipController dispose];
+      _pipController = nil;
+    }
+    result(nil);
+  }
 #endif
      else if ([@"mediaStreamTrackHasTorch" isEqualToString:call.method]) {
     NSDictionary* argsMap = call.arguments;

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -20,6 +20,7 @@
             android:name=".MainActivity"
             android:exported="true"
             android:launchMode="singleTop"
+            android:supportsPictureInPicture="true"
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"

--- a/example/android/app/src/main/java/com/cloudwebrtc/flutterflutterexample/flutter_webrtc_example/MainActivity.java
+++ b/example/android/app/src/main/java/com/cloudwebrtc/flutterflutterexample/flutter_webrtc_example/MainActivity.java
@@ -1,6 +1,24 @@
 package com.cloudwebrtc.flutterflutterexample.flutter_webrtc_example;
 
+import android.content.res.Configuration;
+
+import androidx.annotation.NonNull;
+
+import com.cloudwebrtc.webrtc.FlutterWebRTCPlugin;
+
 import io.flutter.embedding.android.FlutterActivity;
 
 public class MainActivity extends FlutterActivity {
+    @Override
+    public void onUserLeaveHint() {
+        super.onUserLeaveHint();
+        FlutterWebRTCPlugin.onUserLeaveHint();
+    }
+
+    @Override
+    public void onPictureInPictureModeChanged(boolean isInPictureInPictureMode,
+                                              @NonNull Configuration newConfig) {
+        super.onPictureInPictureModeChanged(isInPictureInPictureMode, newConfig);
+        FlutterWebRTCPlugin.onPictureInPictureModeChanged(isInPictureInPictureMode);
+    }
 }

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -53,6 +53,10 @@
 	</dict>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -12,6 +12,7 @@ import 'src/get_user_media_sample.dart'
     if (dart.library.js_interop) 'src/get_user_media_sample_web.dart';
 import 'src/loopback_data_channel_sample.dart';
 import 'src/loopback_sample_unified_tracks.dart';
+import 'src/picture_in_picture_sample.dart';
 import 'src/route_item.dart';
 import 'src/screen_capture_api_sample.dart';
 
@@ -154,6 +155,15 @@ class _MyAppState extends State<MyApp> {
                 context,
                 MaterialPageRoute(
                     builder: (BuildContext context) => DataPacketCryptorSample()));
+          }),
+      RouteItem(
+          title: 'Picture in Picture',
+          push: (BuildContext context) {
+            Navigator.push(
+                context,
+                MaterialPageRoute(
+                    builder: (BuildContext context) =>
+                        PictureInPictureSample()));
           }),
     ];
   }

--- a/example/lib/src/picture_in_picture_sample.dart
+++ b/example/lib/src/picture_in_picture_sample.dart
@@ -1,0 +1,149 @@
+import 'dart:core';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_webrtc/flutter_webrtc.dart';
+
+/*
+ * Picture-in-picture sample
+ */
+class PictureInPictureSample extends StatefulWidget {
+  static String tag = 'picture_in_picture_sample';
+
+  @override
+  _PictureInPictureSampleState createState() => _PictureInPictureSampleState();
+}
+
+class _PictureInPictureSampleState extends State<PictureInPictureSample> {
+  final _renderer = RTCVideoRenderer();
+  final _pip = RTCPictureInPictureController();
+  final _videoKey = GlobalKey();
+  MediaStream? _localStream;
+  bool _supported = false;
+  bool _inCalling = false;
+  String _lastEvent = '';
+
+  @override
+  void initState() {
+    super.initState();
+    _init();
+  }
+
+  @override
+  void deactivate() {
+    super.deactivate();
+    if (_inCalling) {
+      _hangUp();
+    }
+    _pip.dispose();
+    _renderer.dispose();
+  }
+
+  void _init() async {
+    await _renderer.initialize();
+    _supported = await RTCPictureInPictureController.isSupported();
+    _pip.events.listen((event) {
+      setState(() {
+        _lastEvent = event.error == null
+            ? event.state.name
+            : '${event.state.name}: ${event.error}';
+      });
+    });
+    if (mounted) setState(() {});
+  }
+
+  void _makeCall() async {
+    final mediaConstraints = <String, dynamic>{
+      'audio': true,
+      'video': {'facingMode': 'user'},
+    };
+    try {
+      _localStream =
+          await navigator.mediaDevices.getUserMedia(mediaConstraints);
+      _renderer.srcObject = _localStream;
+      _renderer.onResize = _configurePip;
+    } catch (e) {
+      print(e.toString());
+    }
+    if (!mounted) return;
+    setState(() {
+      _inCalling = true;
+    });
+    await _configurePip();
+  }
+
+  Future<void> _configurePip() async {
+    if (_localStream == null) return;
+    await _pip.configure(
+      stream: _localStream,
+      sourceRect: RTCPictureInPictureController.globalRectOf(_videoKey),
+      aspectRatio:
+          _renderer.value.aspectRatio > 0 ? _renderer.value.aspectRatio : null,
+    );
+  }
+
+  void _hangUp() async {
+    try {
+      _renderer.onResize = null;
+      await _localStream?.dispose();
+      _localStream = null;
+      _renderer.srcObject = null;
+      setState(() {
+        _inCalling = false;
+      });
+    } catch (e) {
+      print(e.toString());
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final video = RTCVideoView(_renderer, key: _videoKey, mirror: true);
+    return RTCPictureInPictureBuilder(
+      controller: _pip,
+      child: video,
+      builder: (context, isInPictureInPicture, child) {
+        if (isInPictureInPicture) {
+          return Scaffold(body: child);
+        }
+        return Scaffold(
+          appBar: AppBar(
+            title: Text('Picture in Picture'),
+          ),
+          body: Column(
+            children: [
+              Expanded(
+                child: Container(
+                  margin: EdgeInsets.all(8),
+                  decoration: BoxDecoration(color: Colors.black54),
+                  child: child,
+                ),
+              ),
+              Padding(
+                padding: EdgeInsets.all(8),
+                child: Text(
+                    'supported: $_supported${_lastEvent.isEmpty ? '' : ' | $_lastEvent'}'),
+              ),
+              Padding(
+                padding: EdgeInsets.only(bottom: 16),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    ElevatedButton(
+                      onPressed: _inCalling ? _hangUp : _makeCall,
+                      child: Text(_inCalling ? 'Hang up' : 'Start camera'),
+                    ),
+                    SizedBox(width: 16),
+                    ElevatedButton(
+                      onPressed: _inCalling && _supported ? _pip.start : null,
+                      child: Text('Enter PiP'),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}

--- a/ios/flutter_webrtc.podspec
+++ b/ios/flutter_webrtc.podspec
@@ -16,6 +16,7 @@ A new flutter plugin project.
   s.public_header_files = 'flutter_webrtc/Sources/flutter_webrtc/include/flutter_webrtc/**/*.h'
   s.dependency 'Flutter'
   s.dependency 'WebRTC-SDK', '150.7871.01'
+  s.frameworks = 'AVKit'
   s.ios.deployment_target = '13.0'
   s.static_framework = true
   s.pod_target_xcconfig = {

--- a/ios/flutter_webrtc/Package.swift
+++ b/ios/flutter_webrtc/Package.swift
@@ -31,7 +31,8 @@ let package = Package(
                 .headerSearchPath("include/flutter_webrtc")
             ],
             linkerSettings: [
-                .linkedLibrary("c++")
+                .linkedLibrary("c++"),
+                .linkedFramework("AVKit")
             ]
         )
     ],

--- a/ios/flutter_webrtc/Sources/flutter_webrtc/PictureInPicture/FlutterRTCPictureInPictureController.m
+++ b/ios/flutter_webrtc/Sources/flutter_webrtc/PictureInPicture/FlutterRTCPictureInPictureController.m
@@ -1,0 +1,199 @@
+#import "FlutterRTCPictureInPictureController.h"
+
+#if TARGET_OS_IPHONE
+
+#import "FlutterRTCVideoPlatformView.h"
+
+@implementation FlutterRTCPictureInPictureController {
+  FlutterRTCVideoPlatformView* _contentView;
+  AVPictureInPictureVideoCallViewController* _callViewController;
+  AVPictureInPictureController* _pipController;
+  UIView* _anchorView;
+  CGSize _frameSize;
+  CGFloat _aspectRatio;
+}
+
+@synthesize videoTrack = _videoTrack;
+
++ (BOOL)isSupported {
+  return [AVPictureInPictureController isPictureInPictureSupported];
+}
+
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    _frameSize = CGSizeZero;
+    _aspectRatio = 0;
+    _callViewController = [[AVPictureInPictureVideoCallViewController alloc] init];
+    _contentView = [[FlutterRTCVideoPlatformView alloc] initWithFrame:_callViewController.view.bounds];
+    _contentView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    _contentView.videoGravity = AVLayerVideoGravityResizeAspect;
+    [_callViewController.view addSubview:_contentView];
+    [self updatePreferredContentSize];
+  }
+  return self;
+}
+
+- (UIView*)anchorViewInView:(UIView*)rootView frame:(CGRect)frame {
+  if (!_anchorView) {
+    _anchorView = [[UIView alloc] initWithFrame:frame];
+    _anchorView.backgroundColor = UIColor.clearColor;
+    _anchorView.userInteractionEnabled = NO;
+  }
+  if (_anchorView.superview != rootView) {
+    [_anchorView removeFromSuperview];
+    [rootView insertSubview:_anchorView atIndex:0];
+  }
+  _anchorView.frame = frame;
+  return _anchorView;
+}
+
+- (void)configureWithSourceView:(UIView*)sourceView
+                    aspectRatio:(CGFloat)aspectRatio
+                      autoEnter:(BOOL)autoEnter
+                   videoGravity:(AVLayerVideoGravity)videoGravity {
+  _aspectRatio = aspectRatio;
+  _contentView.videoGravity = videoGravity;
+  [self updatePreferredContentSize];
+
+  AVPictureInPictureControllerContentSource* source =
+      [[AVPictureInPictureControllerContentSource alloc]
+          initWithActiveVideoCallSourceView:sourceView
+                      contentViewController:_callViewController];
+  if (!_pipController) {
+    _pipController = [[AVPictureInPictureController alloc] initWithContentSource:source];
+    _pipController.delegate = self;
+  } else {
+    _pipController.contentSource = source;
+  }
+  _pipController.canStartPictureInPictureAutomaticallyFromInline = autoEnter;
+}
+
+- (BOOL)start {
+  if (!_pipController) {
+    return NO;
+  }
+  if (_pipController.isPictureInPictureActive) {
+    return YES;
+  }
+  if (!_pipController.isPictureInPicturePossible) {
+    return NO;
+  }
+  [_pipController startPictureInPicture];
+  return YES;
+}
+
+- (void)stop {
+  if (_pipController.isPictureInPictureActive) {
+    [_pipController stopPictureInPicture];
+  }
+}
+
+- (BOOL)isActive {
+  return _pipController != nil && _pipController.isPictureInPictureActive;
+}
+
+- (void)dispose {
+  [self stop];
+  self.videoTrack = nil;
+  _pipController.delegate = nil;
+  _pipController = nil;
+  [_anchorView removeFromSuperview];
+  _anchorView = nil;
+  _stateHandler = nil;
+}
+
+- (void)setVideoTrack:(RTCVideoTrack*)videoTrack {
+  RTCVideoTrack* oldValue = _videoTrack;
+  if (oldValue == videoTrack) {
+    return;
+  }
+  if (oldValue) {
+    [oldValue removeRenderer:self];
+  }
+  _videoTrack = videoTrack;
+  _frameSize = CGSizeZero;
+  if (videoTrack) {
+    [videoTrack addRenderer:self];
+  }
+}
+
+- (void)updatePreferredContentSize {
+  CGSize size;
+  if (_aspectRatio > 0) {
+    size = CGSizeMake(round(1000 * _aspectRatio), 1000);
+  } else if (_frameSize.width > 0 && _frameSize.height > 0) {
+    size = _frameSize;
+  } else {
+    size = CGSizeMake(1280, 720);
+  }
+  _callViewController.preferredContentSize = size;
+}
+
+- (void)emitState:(NSString*)state error:(NSString*)error {
+  FlutterRTCPictureInPictureStateHandler handler = self.stateHandler;
+  if (handler) {
+    handler(state, error);
+  }
+}
+
+#pragma mark - RTCVideoRenderer
+
+- (void)setSize:(CGSize)size {
+}
+
+- (void)renderFrame:(nullable RTCVideoFrame*)frame {
+  if (!frame || frame.width <= 0 || frame.height <= 0) {
+    return;
+  }
+  BOOL rotated = frame.rotation == RTCVideoRotation_90 || frame.rotation == RTCVideoRotation_270;
+  CGSize size = rotated ? CGSizeMake(frame.height, frame.width) : CGSizeMake(frame.width, frame.height);
+  if (!CGSizeEqualToSize(size, _frameSize)) {
+    _frameSize = size;
+    if (_aspectRatio <= 0) {
+      __weak FlutterRTCPictureInPictureController* weakSelf = self;
+      dispatch_async(dispatch_get_main_queue(), ^{
+        [weakSelf updatePreferredContentSize];
+      });
+    }
+  }
+  [_contentView renderFrame:frame];
+}
+
+#pragma mark - AVPictureInPictureControllerDelegate
+
+- (void)pictureInPictureControllerWillStartPictureInPicture:
+    (AVPictureInPictureController*)pictureInPictureController {
+  [self emitState:@"willStart" error:nil];
+}
+
+- (void)pictureInPictureControllerDidStartPictureInPicture:
+    (AVPictureInPictureController*)pictureInPictureController {
+  [self emitState:@"started" error:nil];
+}
+
+- (void)pictureInPictureController:(AVPictureInPictureController*)pictureInPictureController
+    failedToStartPictureInPictureWithError:(NSError*)error {
+  [self emitState:@"failed" error:error.localizedDescription];
+}
+
+- (void)pictureInPictureControllerWillStopPictureInPicture:
+    (AVPictureInPictureController*)pictureInPictureController {
+  [self emitState:@"willStop" error:nil];
+}
+
+- (void)pictureInPictureControllerDidStopPictureInPicture:
+    (AVPictureInPictureController*)pictureInPictureController {
+  [self emitState:@"stopped" error:nil];
+}
+
+- (void)pictureInPictureController:(AVPictureInPictureController*)pictureInPictureController
+    restoreUserInterfaceForPictureInPictureStopWithCompletionHandler:
+        (void (^)(BOOL))completionHandler {
+  [self emitState:@"restoreUserInterface" error:nil];
+  completionHandler(YES);
+}
+
+@end
+
+#endif

--- a/ios/flutter_webrtc/Sources/flutter_webrtc/include/flutter_webrtc/FlutterRTCPictureInPictureController.h
+++ b/ios/flutter_webrtc/Sources/flutter_webrtc/include/flutter_webrtc/FlutterRTCPictureInPictureController.h
@@ -1,0 +1,41 @@
+#import <TargetConditionals.h>
+
+#if TARGET_OS_IPHONE
+
+#import <AVKit/AVKit.h>
+#import <UIKit/UIKit.h>
+#import <WebRTC/WebRTC.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef void (^FlutterRTCPictureInPictureStateHandler)(NSString* state,
+                                                       NSString* _Nullable error);
+
+API_AVAILABLE(ios(15.0))
+@interface FlutterRTCPictureInPictureController
+    : NSObject <RTCVideoRenderer, AVPictureInPictureControllerDelegate>
+
+@property(nonatomic, strong, nullable) RTCVideoTrack* videoTrack;
+@property(nonatomic, copy, nullable) FlutterRTCPictureInPictureStateHandler stateHandler;
+
++ (BOOL)isSupported;
+
+/// Returns a transparent view positioned at `frame` inside `rootView`, to be
+/// used as the source view when the video is drawn by a Flutter texture.
+- (UIView*)anchorViewInView:(UIView*)rootView frame:(CGRect)frame;
+
+- (void)configureWithSourceView:(UIView*)sourceView
+                    aspectRatio:(CGFloat)aspectRatio
+                      autoEnter:(BOOL)autoEnter
+                   videoGravity:(AVLayerVideoGravity)videoGravity;
+
+- (BOOL)start;
+- (void)stop;
+- (BOOL)isActive;
+- (void)dispose;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif

--- a/lib/flutter_webrtc.dart
+++ b/lib/flutter_webrtc.dart
@@ -7,6 +7,7 @@ export 'src/helper.dart';
 export 'src/desktop_capturer.dart';
 export 'src/media_devices.dart';
 export 'src/media_recorder.dart';
+export 'src/picture_in_picture.dart';
 export 'src/video_renderer_extension.dart';
 export 'src/native/factory_impl.dart'
     if (dart.library.js_interop) 'src/web/factory_impl.dart';

--- a/lib/src/picture_in_picture.dart
+++ b/lib/src/picture_in_picture.dart
@@ -1,0 +1,222 @@
+import 'dart:async';
+import 'dart:ui' as ui;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+
+import 'package:webrtc_interface/webrtc_interface.dart';
+
+import 'native/event_channel.dart';
+import 'native/utils.dart' if (dart.library.js_interop) 'web/utils.dart';
+
+enum RTCPictureInPictureState {
+  willStart,
+  started,
+  willStop,
+  stopped,
+  failed,
+  restoreUserInterface,
+}
+
+class RTCPictureInPictureEvent {
+  const RTCPictureInPictureEvent(this.state, {this.error});
+
+  final RTCPictureInPictureState state;
+
+  /// Set when [state] is [RTCPictureInPictureState.failed].
+  final String? error;
+}
+
+/// Controls native picture-in-picture for a video call.
+///
+/// On Android the whole Flutter view is shown in the picture-in-picture
+/// window, so the app should render a reduced layout while [value] is true
+/// (see [RTCPictureInPictureBuilder]). On iOS the system shows only the video
+/// track passed to [configure]; the Flutter UI is not visible while active.
+///
+/// The value of this notifier is whether picture-in-picture is currently
+/// active.
+class RTCPictureInPictureController extends ValueNotifier<bool> {
+  RTCPictureInPictureController() : super(false) {
+    if (!kIsWeb) {
+      _subscription = FlutterWebRTCEventChannel.instance.handleEvents.stream
+          .listen(_onEvent);
+    }
+  }
+
+  StreamSubscription<Map<String, dynamic>>? _subscription;
+  final _events = StreamController<RTCPictureInPictureEvent>.broadcast();
+  bool _disposed = false;
+
+  Stream<RTCPictureInPictureEvent> get events => _events.stream;
+
+  bool get isInPictureInPicture => value;
+
+  static Future<bool> isSupported() async {
+    if (kIsWeb) return false;
+    return await WebRTC.invokeMethod<bool, dynamic>('pipIsSupported') ?? false;
+  }
+
+  /// The global rect of the widget attached to [key], in logical pixels.
+  /// Useful as the `sourceRect` of [configure].
+  static Rect? globalRectOf(GlobalKey key) {
+    final renderObject = key.currentContext?.findRenderObject();
+    if (renderObject is! RenderBox || !renderObject.hasSize) return null;
+    return renderObject.localToGlobal(Offset.zero) & renderObject.size;
+  }
+
+  /// Configures the picture-in-picture session. Can be called again to change
+  /// the video track, the source rect or the aspect ratio while active.
+  ///
+  /// [stream] and [trackId] select the video rendered on iOS; when [stream] is
+  /// omitted the current track is kept. On Android they are ignored: pass
+  /// [aspectRatio] (for example `renderer.value.aspectRatio`) so the window
+  /// matches the video.
+  ///
+  /// [sourceRect] is the on-screen rect of the video view, in logical pixels,
+  /// used by the system for the enter/exit animation.
+  ///
+  /// [autoEnter] enters picture-in-picture when the app goes to the
+  /// background. On Android 8 to 11 this requires forwarding
+  /// `Activity.onUserLeaveHint` to `FlutterWebRTCPlugin.onUserLeaveHint()`.
+  ///
+  /// [platformViewId] (iOS only) is the `textureId` of an
+  /// `RTCVideoPlatformViewController`, used as the animation source instead of
+  /// [sourceRect].
+  Future<void> configure({
+    MediaStream? stream,
+    String? trackId,
+    Rect? sourceRect,
+    double? aspectRatio,
+    bool autoEnter = true,
+    bool seamlessResize = true,
+    RTCVideoViewObjectFit objectFit =
+        RTCVideoViewObjectFit.RTCVideoViewObjectFitContain,
+    int? platformViewId,
+  }) async {
+    _checkDisposed();
+    final devicePixelRatio =
+        ui.PlatformDispatcher.instance.implicitView?.devicePixelRatio ?? 1.0;
+    await WebRTC.invokeMethod('pipConfigure', <String, dynamic>{
+      'streamId': stream?.id ?? '',
+      'ownerTag': stream?.ownerTag ?? '',
+      'trackId': trackId ?? '0',
+      if (sourceRect != null)
+        'sourceRect': <String, double>{
+          'left': sourceRect.left,
+          'top': sourceRect.top,
+          'right': sourceRect.right,
+          'bottom': sourceRect.bottom,
+        },
+      'devicePixelRatio': devicePixelRatio,
+      if (aspectRatio != null && aspectRatio > 0) 'aspectRatio': aspectRatio,
+      'autoEnter': autoEnter,
+      'seamlessResize': seamlessResize,
+      'objectFit':
+          objectFit == RTCVideoViewObjectFit.RTCVideoViewObjectFitCover
+              ? 'cover'
+              : 'contain',
+      if (platformViewId != null) 'platformViewId': platformViewId,
+    });
+  }
+
+  /// Enters picture-in-picture now. Returns false when the request was
+  /// refused, for example because the activity is not visible or the app
+  /// does not declare `android:supportsPictureInPicture`.
+  Future<bool> start() async {
+    _checkDisposed();
+    return await WebRTC.invokeMethod<bool, dynamic>('pipStart') ?? false;
+  }
+
+  /// Leaves picture-in-picture. Android has no API for this; the window is
+  /// closed by the user or by bringing the activity to the front.
+  Future<void> stop() async {
+    _checkDisposed();
+    await WebRTC.invokeMethod('pipStop');
+  }
+
+  Future<bool> isActive() async {
+    _checkDisposed();
+    return await WebRTC.invokeMethod<bool, dynamic>('pipIsActive') ?? false;
+  }
+
+  @override
+  Future<void> dispose() async {
+    if (_disposed) return;
+    _disposed = true;
+    await _subscription?.cancel();
+    _subscription = null;
+    await _events.close();
+    if (!kIsWeb) {
+      await WebRTC.invokeMethod('pipDispose');
+    }
+    super.dispose();
+  }
+
+  void _checkDisposed() {
+    if (_disposed) {
+      throw StateError('RTCPictureInPictureController is disposed');
+    }
+  }
+
+  void _onEvent(Map<String, dynamic> event) {
+    final map = event['pictureInPictureStateChanged'];
+    if (map is! Map || _disposed) return;
+    final state = _stateFromString(map['state'] as String?);
+    if (state == null) return;
+    switch (state) {
+      case RTCPictureInPictureState.started:
+        value = true;
+        break;
+      case RTCPictureInPictureState.stopped:
+      case RTCPictureInPictureState.failed:
+        value = false;
+        break;
+      default:
+        break;
+    }
+    _events.add(RTCPictureInPictureEvent(state, error: map['error'] as String?));
+  }
+
+  static RTCPictureInPictureState? _stateFromString(String? state) {
+    switch (state) {
+      case 'willStart':
+        return RTCPictureInPictureState.willStart;
+      case 'started':
+        return RTCPictureInPictureState.started;
+      case 'willStop':
+        return RTCPictureInPictureState.willStop;
+      case 'stopped':
+        return RTCPictureInPictureState.stopped;
+      case 'failed':
+        return RTCPictureInPictureState.failed;
+      case 'restoreUserInterface':
+        return RTCPictureInPictureState.restoreUserInterface;
+    }
+    return null;
+  }
+}
+
+/// Rebuilds when the picture-in-picture state of [controller] changes.
+class RTCPictureInPictureBuilder extends StatelessWidget {
+  const RTCPictureInPictureBuilder({
+    super.key,
+    required this.controller,
+    required this.builder,
+    this.child,
+  });
+
+  final RTCPictureInPictureController controller;
+  final Widget Function(
+      BuildContext context, bool isInPictureInPicture, Widget? child) builder;
+  final Widget? child;
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<bool>(
+      valueListenable: controller,
+      builder: builder,
+      child: child,
+    );
+  }
+}

--- a/lib/src/picture_in_picture.dart
+++ b/lib/src/picture_in_picture.dart
@@ -112,10 +112,9 @@ class RTCPictureInPictureController extends ValueNotifier<bool> {
       if (aspectRatio != null && aspectRatio > 0) 'aspectRatio': aspectRatio,
       'autoEnter': autoEnter,
       'seamlessResize': seamlessResize,
-      'objectFit':
-          objectFit == RTCVideoViewObjectFit.RTCVideoViewObjectFitCover
-              ? 'cover'
-              : 'contain',
+      'objectFit': objectFit == RTCVideoViewObjectFit.RTCVideoViewObjectFitCover
+          ? 'cover'
+          : 'contain',
       if (platformViewId != null) 'platformViewId': platformViewId,
     });
   }
@@ -175,7 +174,8 @@ class RTCPictureInPictureController extends ValueNotifier<bool> {
       default:
         break;
     }
-    _events.add(RTCPictureInPictureEvent(state, error: map['error'] as String?));
+    _events
+        .add(RTCPictureInPictureEvent(state, error: map['error'] as String?));
   }
 
   static RTCPictureInPictureState? _stateFromString(String? state) {

--- a/test/unit/picture_in_picture_test.dart
+++ b/test/unit/picture_in_picture_test.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/services.dart';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:flutter_webrtc/src/picture_in_picture.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  final messenger =
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+  final methodChannel = MethodChannel('FlutterWebRTC.Method');
+  final eventChannel = MethodChannel('FlutterWebRTC.Event');
+  final calls = <MethodCall>[];
+
+  setUp(() {
+    calls.clear();
+    messenger.setMockMethodCallHandler(methodChannel, (call) async {
+      calls.add(call);
+      switch (call.method) {
+        case 'pipIsSupported':
+        case 'pipStart':
+          return true;
+        case 'pipIsActive':
+          return false;
+      }
+      return null;
+    });
+    messenger.setMockMethodCallHandler(eventChannel, (call) async => null);
+  });
+
+  tearDown(() {
+    messenger.setMockMethodCallHandler(methodChannel, null);
+    messenger.setMockMethodCallHandler(eventChannel, null);
+  });
+
+  Future<void> emit(Map<String, dynamic> event) async {
+    await messenger.handlePlatformMessage(
+      'FlutterWebRTC.Event',
+      const StandardMethodCodec().encodeSuccessEnvelope(event),
+      (_) {},
+    );
+    await pumpEventQueue();
+  }
+
+  test('isSupported forwards to the platform', () async {
+    expect(await RTCPictureInPictureController.isSupported(), isTrue);
+    expect(calls.map((c) => c.method), contains('pipIsSupported'));
+  });
+
+  test('configure sends the expected arguments', () async {
+    final controller = RTCPictureInPictureController();
+    await controller.configure(
+      sourceRect: Rect.fromLTWH(10, 20, 100, 50),
+      aspectRatio: 1.5,
+      autoEnter: false,
+    );
+    final call = calls.singleWhere((c) => c.method == 'pipConfigure');
+    final args = call.arguments as Map;
+    expect(args['streamId'], '');
+    expect(args['trackId'], '0');
+    expect(args['aspectRatio'], 1.5);
+    expect(args['autoEnter'], isFalse);
+    expect(args['seamlessResize'], isTrue);
+    expect(args['objectFit'], 'contain');
+    expect(args['sourceRect'],
+        {'left': 10.0, 'top': 20.0, 'right': 110.0, 'bottom': 70.0});
+    await controller.dispose();
+    expect(calls.last.method, 'pipDispose');
+  });
+
+  test('state events update the notifier and the stream', () async {
+    final controller = RTCPictureInPictureController();
+    final received = <RTCPictureInPictureState>[];
+    controller.events.listen((e) => received.add(e.state));
+
+    await emit({'event': 'pictureInPictureStateChanged', 'state': 'started'});
+    expect(controller.value, isTrue);
+
+    await emit({
+      'event': 'pictureInPictureStateChanged',
+      'state': 'failed',
+      'error': 'boom',
+    });
+    expect(controller.value, isFalse);
+
+    await emit({'event': 'onDeviceChange'});
+
+    expect(received, [
+      RTCPictureInPictureState.started,
+      RTCPictureInPictureState.failed,
+    ]);
+    await controller.dispose();
+  });
+
+  test('methods throw after dispose', () async {
+    final controller = RTCPictureInPictureController();
+    await controller.dispose();
+    expect(() => controller.start(), throwsStateError);
+  });
+}


### PR DESCRIPTION
Adds native picture-in-picture for video calls on Android 8+ and iOS 15+, driven from Dart through `RTCPictureInPictureController` and `RTCPictureInPictureBuilder`.

Related: #1193, #1645

## Android

- `PictureInPictureManager` builds the `PictureInPictureParams` (aspect ratio, source rect hint, auto enter and seamless resize on Android 12+) and calls `Activity.enterPictureInPictureMode`.
- Mode changes are detected from the activity lifecycle and emitted as `pictureInPictureStateChanged` on the existing `FlutterWebRTC.Event` channel.
- `FlutterWebRTCPlugin.onUserLeaveHint()` and `onPictureInPictureModeChanged()` are available for apps that need auto enter on Android 8-11, where the system only allows entering from `Activity.onUserLeaveHint`.
- The whole Flutter view is shown in the window, so apps switch to a reduced layout with `RTCPictureInPictureBuilder`.

## iOS

- `FlutterRTCPictureInPictureController` renders the selected `RTCVideoTrack` into a `FlutterRTCVideoPlatformView` hosted by an `AVPictureInPictureVideoCallViewController`, using the video-call content source of `AVPictureInPictureController`.
- The animation source is the `RTCVideoPlatFormView` when one is used (`platformViewId`), otherwise a transparent anchor view placed at `sourceRect` inside the Flutter root view.
- `FlutterRTCVideoPlatformView` gains a `videoGravity` property (default unchanged).
- The duplicated video track lookup in `videoRendererSetSrcObject` and `videoPlatformViewRendererSetSrcObject` is extracted into `videoTrackForStreamId:ownerTag:trackId:`.
- New `multitaskingCameraAccess` option for `WebRTC.initialize`, enabling `AVCaptureSession.multitaskingCameraAccessEnabled` on iOS 16+ for apps holding the entitlement.

### Local camera in the background

Picture-in-picture renders any `RTCVideoTrack`. Remote tracks keep rendering while the app is in the background, which is the video call use case. A local camera track freezes on its last frame when the app leaves the foreground, because iOS interrupts `AVCaptureSession` for apps without the `com.apple.developer.avfoundation.multitasking-camera-access` entitlement; capture resumes when the app returns. Apps granted the entitlement can keep the camera running with `WebRTC.initialize(options: {'multitaskingCameraAccess': true})`. No entitlement is needed for the remote video case.

## Method channel

`pipIsSupported`, `pipConfigure`, `pipStart`, `pipStop`, `pipIsActive`, `pipDispose`. Web and desktop report `isSupported == false`.

## Also included

- Example page "Picture in Picture", with the manifest and `MainActivity` changes on Android and `UIBackgroundModes` on iOS.
- `Documentation/PICTURE_IN_PICTURE.md` with setup steps for both platforms, plus a README entry.
- Unit tests for the Dart layer.

## Testing

- `flutter analyze` and `flutter test` pass.
- Example builds for Android (`flutter build apk`) and iOS (`flutter build ios --simulator`).
- Verified on physical devices in a production app on both platforms.

