### PR TITLE
fix(android): guard null cameraName before reuse check in getUserMedia

### DIFF
--- a/android/src/main/java/com/cloudwebrtc/webrtc/GetUserMediaImpl.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/GetUserMediaImpl.java
@@ -764,12 +764,16 @@ public class GetUserMediaImpl {
         final boolean requestedFacingFront = isFacing;
         for (Map.Entry<String, VideoCapturerInfoEx> entry : mVideoCapturers.entrySet()) {
             VideoCapturerInfoEx existing = entry.getValue();
+            // Screen capturers are registered with a null cameraName, so these
+            // checks must run before cameraName is dereferenced below.
+            if (existing.isScreenCapture || existing.primaryTrackId != null
+                    || existing.videoSource == null || existing.cameraName == null) {
+                continue;
+            }
             boolean sameCamera = (deviceId != null && !deviceId.isEmpty())
                     ? existing.cameraName.equals(deviceId)
                     : cameraEnumerator.isFrontFacing(existing.cameraName) == requestedFacingFront;
-            if (!existing.isScreenCapture && existing.primaryTrackId == null
-                    && existing.videoSource != null && existing.cameraName != null
-                    && sameCamera) {
+            if (sameCamera) {
                 Log.w(TAG, "getUserMedia(video): camera already active (track=" + entry.getKey()
                         + "), reusing VideoSource to prevent concurrent camera access");
                 return buildSharedVideoTrack(existing, entry.getKey(), mediaStream);


### PR DESCRIPTION
Fixes #2161.

### Problem

The capturer-reuse loop added in #2013 computes `sameCamera` — which dereferences `existing.cameraName` — one line *before* the `isScreenCapture` and `cameraName != null` checks that would have prevented it:

```java
boolean sameCamera = (deviceId != null && !deviceId.isEmpty())
        ? existing.cameraName.equals(deviceId)
        : cameraEnumerator.isFrontFacing(existing.cameraName) == requestedFacingFront;
if (!existing.isScreenCapture && existing.primaryTrackId == null
        && existing.videoSource != null && existing.cameraName != null   // too late
        && sameCamera) {
```

Screen capturers are registered in `mVideoCapturers` with a null `cameraName` — `getDisplayMedia` sets `isScreenCapture`, `capturer` and the dimensions, but never `cameraName`. So any `getUserMedia({video})` issued while a screen share is active walks over that entry and throws on the main thread, killing the process.

**Both branches are affected.** The issue report shows the `String.equals` NPE, which needs a non-empty `deviceId`. Callers that select by facing mode instead — the common path — pass null into `CameraEnumerator.isFrontFacing`. A fix that only null-checks `deviceId` would leave that case broken.

### Fix

Hoist the existing conditions above the dereference as a `continue`. Semantics are unchanged; the loop now reads as "skip entries that cannot be reused".

### Repro

1. Join a session with the camera off.
2. Start a screen share, so an `OrientationAwareScreenCapturer` is registered in `mVideoCapturers`.
3. Enable the camera.

Present in 1.5.0 through 1.6.2; absent in 1.4.0 and earlier, where this loop does not exist.