### PR TITLE
fix(darwin): fix resource leak by releasing event channel stream handlers

### DIFF
--- a/common/darwin/Classes/FlutterRTCVideoRenderer.m
+++ b/common/darwin/Classes/FlutterRTCVideoRenderer.m
@@ -63,6 +63,8 @@
 }
 
 - (void)dispose {
+  [_eventChannel setStreamHandler:nil];
+  _eventChannel = nil;
   os_unfair_lock_lock(&_lock);
   [_registry unregisterTexture:_textureId];
   _textureId = -1;

--- a/common/darwin/Classes/FlutterWebRTCPlugin.m
+++ b/common/darwin/Classes/FlutterWebRTCPlugin.m
@@ -967,6 +967,8 @@ static void FlutterWebRTCApplyFieldTrials(void) {
     RTCPeerConnection* peerConnection = self.peerConnections[peerConnectionId];
     if (peerConnection) {
       [peerConnection close];
+      [peerConnection.eventChannel setStreamHandler:nil];
+      peerConnection.eventChannel = nil;
       [self.peerConnections removeObjectForKey:peerConnectionId];
 
       // Clean up peerConnection's streams and tracks
@@ -977,6 +979,8 @@ static void FlutterWebRTCApplyFieldTrials(void) {
       NSMutableDictionary<NSString*, RTCDataChannel*>* dataChannels = peerConnection.dataChannels;
       for (NSString* dataChannelId in dataChannels) {
         dataChannels[dataChannelId].delegate = nil;
+        [dataChannels[dataChannelId].eventChannel setStreamHandler:nil];
+        dataChannels[dataChannelId].eventChannel = nil;
         // There is no need to close the RTCDataChannel because it is owned by the
         // RTCPeerConnection and the latter will close the former.
       }


### PR DESCRIPTION
`setStreamHandler:` hands the object to the binary messenger, which retains it.
Until the handler is cleared, that object is never deallocated — taking it out
of the plugin's own dictionaries does not help.

Three places on darwin never clear theirs:

- `peerConnectionClose` / `peerConnectionDispose` — the `RTCPeerConnection`.
  This is the costly one: closed or not, it still holds its native
  `webrtc::PeerConnection`.
- the `dataChannels` loop in the same block — data channels closed with their
  peer connection never reach `dataChannelClose`.
- `FlutterRTCVideoRenderer`'s `dispose` — the renderer. There is no `dealloc`
  either.

Everywhere else already does this. `dataChannelClose` and the frame cryptor
call `setStreamHandler:nil`, and on the C++ side `~EventChannelProxyImpl` calls
`SetStreamHandler(nullptr)` — its owners being these same three. Windows and
Linux release all three; darwin does not.

## Measured

A LiveKit client that stays connected all day (macOS 26.6.2, ~20 participants).
It reconnects when the network hiccups or the machine sleeps, about 40 times a
day. Live objects from `heap <pid>`:

| connections made | `RTCPeerConnection` | with this change |
|---|---|---|
| 1 | 2 | 2 |
| 2 | 4 | 2 |
| 3 | 6 | 2 |

After four days: 318 `RTCPeerConnection` and 1111 `FlutterEventChannel` still
alive, and the process footprint up from 390 MB to 489 MB. Without a reconnect
nothing grows at all, which is why a short session shows nothing.

Reconnects were forced with `kill -STOP` / `kill -CONT` on the app.

`example/` builds for macOS with the change applied.

## Not covered

Android has not been checked for the same pattern.
`-[FlutterWebRTCPlugin peerConnectionClose:]` has no callers in this repository
and is left alone.
