### PR TITLE
fix(desktop): keep PeerConnection observer alive during disposal

### DIFF
--- a/Documentation/desktop-peerconnection-disposal.md
+++ b/Documentation/desktop-peerconnection-disposal.md
@@ -1,0 +1,53 @@
+# Desktop PeerConnection disposal regression check
+
+`example/lib/peer_connection_dispose_smoke.dart` exercises native observer
+teardown on Windows and Linux. It creates a remote audio stream from a synthetic
+SDP offer, waits for `onAddStream`, then calls `dispose()` followed by `close()`.
+It repeats this sequence ten times. No account, microphone capture, ICE server,
+or media connection is needed.
+
+Run this with a desktop runner. `flutter test` uses mocked platform channels and
+cannot exercise the native observer lifetime. From the repository root:
+
+```sh
+cd example
+flutter pub get
+flutter run -d linux -t lib/peer_connection_dispose_smoke.dart
+```
+
+On Windows, replace `-d linux` with `-d windows`. Success prints:
+
+```text
+PASS: 10 native PeerConnections disposed with remote audio
+```
+
+To check the native process exit code on Windows (PowerShell, from `example`):
+
+```powershell
+flutter build windows --debug -t lib/peer_connection_dispose_smoke.dart
+$process = Start-Process -FilePath .\build\windows\x64\runner\Debug\flutter_webrtc_example.exe -WindowStyle Hidden -Wait -PassThru
+$process.ExitCode
+```
+
+The expected exit code is zero. A Dart failure exits with code 1. A native
+access violation can terminate the process before Dart can report a failure.
+
+## Failure being exercised
+
+In `common/cpp/src/flutter_peerconnection.cc`, `RTCPeerConnectionDispose`
+previously erased `peerconnection_observers_[uuid]` while the native connection
+still had that observer registered. A later `RTCPeerConnectionClose` called
+libwebrtc `Close()`, which can deliver `OnRemoveStream` for remaining remote
+streams. That callback could access the deleted observer.
+
+Disposal now closes the native connection while its observer is still alive,
+unregisters the observer, then erases it. The connection map entry remains for
+the subsequent `peerConnectionClose` call, preserving that cleanup sequence.
+
+Restore the regular example entry point after the check:
+
+```sh
+flutter run -d windows -t lib/main.dart
+```
+
+Use `-d linux` for the Linux example.

--- a/common/cpp/src/flutter_peerconnection.cc
+++ b/common/cpp/src/flutter_peerconnection.cc
@@ -409,9 +409,15 @@ void FlutterPeerConnection::RTCPeerConnectionDispose(
     const std::string& uuid,
     std::unique_ptr<MethodResultProxy> result) {
   auto it = base_->peerconnection_observers_.find(uuid);
-  if (it != base_->peerconnection_observers_.end())
+  if (it != base_->peerconnection_observers_.end()) {
+    // Close() can still deliver OnRemoveStream callbacks. Keep the observer
+    // alive until native teardown completes, then detach it before deletion.
+    pc->Close();
+    pc->DeRegisterRTCPeerConnectionObserver();
     base_->peerconnection_observers_.erase(it);
+  }
 
+  // Leave the connection map entry for a subsequent peerConnectionClose call.
   result->Success();
 }
 

--- a/example/lib/peer_connection_dispose_smoke.dart
+++ b/example/lib/peer_connection_dispose_smoke.dart
@@ -1,0 +1,72 @@
+// Native regression check: run with the Windows or Linux example runner.
+// See Documentation/desktop-peerconnection-disposal.md for instructions.
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_webrtc/flutter_webrtc.dart';
+
+// Remote audio without an MSID exercises the native OnAddStream/OnRemoveStream
+// path. No answer is created, so ICE gathering and media transport never start.
+const _remoteOffer = 'v=0\r\n'
+    'o=- 1 1 IN IP4 127.0.0.1\r\n'
+    's=-\r\n'
+    't=0 0\r\n'
+    'a=group:BUNDLE 0\r\n'
+    'm=audio 9 UDP/TLS/RTP/SAVPF 111\r\n'
+    'c=IN IP4 0.0.0.0\r\n'
+    'a=ice-ufrag:test\r\n'
+    'a=ice-pwd:012345678901234567890123\r\n'
+    'a=fingerprint:sha-256 '
+    '00:01:02:03:04:05:06:07:08:09:0A:0B:0C:0D:0E:0F:'
+    '10:11:12:13:14:15:16:17:18:19:1A:1B:1C:1D:1E:1F\r\n'
+    'a=setup:actpass\r\n'
+    'a=mid:0\r\n'
+    'a=sendonly\r\n'
+    'a=rtcp-mux\r\n'
+    'a=rtpmap:111 opus/48000/2\r\n';
+
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  runApp(const SizedBox.shrink());
+  final watchdog = Timer(const Duration(seconds: 60), () {
+    stderr.writeln('FAIL: native PeerConnection disposal timed out');
+    exit(1);
+  });
+
+  try {
+    if (!Platform.isLinux && !Platform.isWindows) {
+      throw StateError('This regression check requires Linux or Windows');
+    }
+    for (var iteration = 1; iteration <= 10; iteration++) {
+      final connection = await createPeerConnection({
+        'iceServers': <Map<String, dynamic>>[],
+        'sdpSemantics': 'unified-plan',
+      });
+      final remoteStreamAdded = Completer<void>();
+      connection.onAddStream = (stream) {
+        if (stream.getAudioTracks().isNotEmpty &&
+            !remoteStreamAdded.isCompleted) {
+          remoteStreamAdded.complete();
+        }
+      };
+      await connection.setRemoteDescription(
+        RTCSessionDescription(_remoteOffer, 'offer'),
+      );
+      await remoteStreamAdded.future.timeout(const Duration(seconds: 5));
+
+      // Cancel the Dart subscription first. The native observer must survive
+      // all Close() callbacks even though it is disposed before Dart close().
+      stdout.writeln('Disposing PeerConnection $iteration with remote audio');
+      await connection.dispose();
+      await connection.close();
+    }
+    stdout.writeln('PASS: 10 native PeerConnections disposed with remote audio');
+    watchdog.cancel();
+    exit(0);
+  } catch (error, stackTrace) {
+    stderr.writeln('FAIL: $error\n$stackTrace');
+    watchdog.cancel();
+    exit(1);
+  }
+}


### PR DESCRIPTION
## Problem

On Linux and Windows, disposing a PeerConnection with a remaining remote audio
stream and then closing it can crash the native process:

```dart
await connection.dispose();
await connection.close();
```

With `flutter_webrtc 1.6.2+hotfix.1` and `libwebrtc.m150.7871.01`, the Windows
reproducer exits on its first iteration with `0xC0000005` / `-1073741819`
(access violation), immediately after the audio device termination logs. The
equivalent Linux regression check previously reproduced a SIGSEGV during
`libwebrtc::RTCPeerConnectionImpl::Close()`.

The included reproducer needs no SIP account, microphone capture, ICE server,
or media connection. It only applies a synthetic remote audio offer without an
MSID, waits for `onAddStream`, and performs the disposal sequence.

## Root cause and affected files

The defect is still present on `main` at
`fb8db5517ea158d025bd6834826c90ba686556a0`:

1. [`lib/src/native/rtc_peerconnection_impl.dart`, `dispose()`](https://github.com/flutter-webrtc/flutter-webrtc/blob/fb8db5517ea158d025bd6834826c90ba686556a0/lib/src/native/rtc_peerconnection_impl.dart#L294-L301)
   cancels the Dart event subscription and invokes `peerConnectionDispose`.
2. [`common/cpp/src/flutter_peerconnection.cc`, `RTCPeerConnectionDispose()`](https://github.com/flutter-webrtc/flutter-webrtc/blob/fb8db5517ea158d025bd6834826c90ba686556a0/common/cpp/src/flutter_peerconnection.cc#L407-L416)
   erases the native observer from `peerconnection_observers_` without closing
   the connection or unregistering that observer.
3. [`RTCPeerConnectionClose()` in the same C++ file](https://github.com/flutter-webrtc/flutter-webrtc/blob/fb8db5517ea158d025bd6834826c90ba686556a0/common/cpp/src/flutter_peerconnection.cc#L394-L405)
   subsequently calls native `Close()`.
4. [`libwebrtc::RTCPeerConnectionImpl::Close()`](https://github.com/webrtc-sdk/libwebrtc/blob/libwebrtc.m150.7871.01/src/rtc_peerconnection_impl.cc)
   calls `observer_->OnRemoveStream(stream)` for remaining remote streams.
   Its non-null observer pointer can now refer to the deleted plugin observer.

Both Linux and Windows compile this shared C++ implementation.

## Proposed fix

In `RTCPeerConnectionDispose()`, close the native connection while the observer
is still alive, then unregister the observer before erasing it. Keep the
connection map entry so a subsequent Dart `close()` continues to perform the
existing map cleanup. The second native `Close()` is a no-op once its underlying
connection has been released.

This is a focused fix to the dispose-then-close path; it does not attempt a
broader redesign of event-channel or PeerConnection ownership.

Related: #2050 also addresses observer deregistration and event-channel cleanup.
This proposal adds a reproducible native regression check and closes the native
connection before deleting its observer. #1360 is earlier desktop close/dispose
lifetime work. Neither is claimed as fixed by this PR.

## Validation

- Windows x64, Flutter 3.44.2 / Dart 3.12.2, libwebrtc m150.7871.01.
- Before the fix: the equivalent native test using the unmodified published
  plugin crashed on the first iteration with `0xC0000005`.
- After the fix: built and ran the new entry point in this repository's own
  Windows example, using the patched local plugin directly. All ten iterations
  passed and the native process exited with code 0.
- `flutter analyze --no-pub lib/peer_connection_dispose_smoke.dart` from
  `example/`: no issues found.
- The equivalent patch/reproducer had previously passed ten iterations on
  Linux after reproducing the crash there. The new upstream example entry point
  has been run on Windows; it has not been rerun on Linux in this checkout.

Run from `example/`:

```sh
flutter pub get
flutter run -d windows -t lib/peer_connection_dispose_smoke.dart
# Or on Linux:
flutter run -d linux -t lib/peer_connection_dispose_smoke.dart
```

Expected output:

```text
PASS: 10 native PeerConnections disposed with remote audio
```

`Documentation/desktop-peerconnection-disposal.md` explains how to check the
native exit code. This must run with a desktop plugin; mocked `flutter test`
platform channels cannot detect this native use-after-free. Real call hangups,
hold/resume, and other platforms are outside this automated smoke check.
