### PR TITLE
fix(darwin): release event channel handlers on dispose only

### DIFF
--- a/common/darwin/Classes/FlutterRTCPeerConnection.h
+++ b/common/darwin/Classes/FlutterRTCPeerConnection.h
@@ -9,6 +9,10 @@
 @property(nonatomic, strong, nonnull) NSString* flutterId;
 @property(nonatomic, strong, nullable) FlutterEventSink eventSink;
 @property(nonatomic, strong, nullable) FlutterEventChannel* eventChannel;
+// Set when the plugin has closed this connection. A closed connection stays
+// registered until it is disposed so that its event channel handler can be
+// released at that point.
+@property(nonatomic, assign) BOOL closedByPlugin;
 @end
 
 @interface FlutterWebRTCPlugin (RTCPeerConnection)

--- a/common/darwin/Classes/FlutterRTCPeerConnection.m
+++ b/common/darwin/Classes/FlutterRTCPeerConnection.m
@@ -37,6 +37,15 @@
                            OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
+- (BOOL)closedByPlugin {
+  return [objc_getAssociatedObject(self, _cmd) boolValue];
+}
+
+- (void)setClosedByPlugin:(BOOL)closedByPlugin {
+  objc_setAssociatedObject(self, @selector(closedByPlugin), @(closedByPlugin),
+                           OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
 - (NSMutableDictionary<NSString*, RTCDataChannel*>*)dataChannels {
   return objc_getAssociatedObject(self, _cmd);
 }

--- a/common/darwin/Classes/FlutterWebRTCPlugin.m
+++ b/common/darwin/Classes/FlutterWebRTCPlugin.m
@@ -969,6 +969,7 @@ static void FlutterWebRTCApplyFieldTrials(void) {
     if (peerConnection) {
       // Closing twice is harmless, the native peer connection ignores the second call.
       [peerConnection close];
+      peerConnection.closedByPlugin = YES;
 
       // Clean up peerConnection's streams and tracks
       [peerConnection.remoteStreams removeAllObjects];
@@ -1954,9 +1955,12 @@ static void FlutterWebRTCApplyFieldTrials(void) {
 - (BOOL)hasOpenPeerConnection {
   // A closed peer connection stays registered until it is disposed so that its
   // event channel handler can be released at that point. It should not keep the
-  // audio session alive in the meantime.
+  // audio session alive in the meantime. The plugin records the close itself
+  // rather than asking the connection for its signaling state, because that
+  // getter is a blocking hop to the signaling thread for every registered
+  // connection and this runs on the platform thread.
   for (RTCPeerConnection* peerConnection in self.peerConnections.allValues) {
-    if (peerConnection.signalingState != RTCSignalingStateClosed) {
+    if (!peerConnection.closedByPlugin) {
       return YES;
     }
   }

--- a/common/darwin/Classes/FlutterWebRTCPlugin.m
+++ b/common/darwin/Classes/FlutterWebRTCPlugin.m
@@ -963,7 +963,7 @@ static void FlutterWebRTCApplyFieldTrials(void) {
              [@"peerConnectionDispose" isEqualToString:call.method]) {
     NSDictionary* argsMap = call.arguments;
     NSString* peerConnectionId = argsMap[@"peerConnectionId"];
-    BOOL dispose = [@"peerConnectionDispose" isEqualToString:call.method];
+    BOOL isDispose = [@"peerConnectionDispose" isEqualToString:call.method];
 
     RTCPeerConnection* peerConnection = self.peerConnections[peerConnectionId];
     if (peerConnection) {
@@ -983,14 +983,10 @@ static void FlutterWebRTCApplyFieldTrials(void) {
         dataChannels[dataChannelId].delegate = nil;
       }
 
-      if (dispose) {
-        // Release the event channel stream handlers only on dispose. The Dart
-        // side cancels its event subscription right before it calls dispose, and
-        // that cancel is a method call on the same channel. Releasing the handler
-        // on close would leave that cancel with no handler to answer it, which
-        // surfaces as a MissingPluginException for callers that close first and
-        // dispose later. The peer connection stays registered until dispose so
-        // the handlers can still be released at that point.
+      if (isDispose) {
+        // Dart cancels its event subscriptions before it calls dispose, so this
+        // is the first point where the stream handlers can go without leaving a
+        // pending cancel unanswered. Releasing them on close would do exactly that.
         for (NSString* dataChannelId in dataChannels) {
           [dataChannels[dataChannelId].eventChannel setStreamHandler:nil];
           dataChannels[dataChannelId].eventChannel = nil;
@@ -1953,12 +1949,9 @@ static void FlutterWebRTCApplyFieldTrials(void) {
 }
 
 - (BOOL)hasOpenPeerConnection {
-  // A closed peer connection stays registered until it is disposed so that its
-  // event channel handler can be released at that point. It should not keep the
-  // audio session alive in the meantime. The plugin records the close itself
-  // rather than asking the connection for its signaling state, because that
-  // getter is a blocking hop to the signaling thread for every registered
-  // connection and this runs on the platform thread.
+  // Closed connections stay registered until dispose but must not keep the
+  // audio session alive. The flag avoids a blocking signalingState read per
+  // connection on the platform thread.
   for (RTCPeerConnection* peerConnection in self.peerConnections.allValues) {
     if (!peerConnection.closedByPlugin) {
       return YES;

--- a/common/darwin/Classes/FlutterWebRTCPlugin.m
+++ b/common/darwin/Classes/FlutterWebRTCPlugin.m
@@ -963,28 +963,42 @@ static void FlutterWebRTCApplyFieldTrials(void) {
              [@"peerConnectionDispose" isEqualToString:call.method]) {
     NSDictionary* argsMap = call.arguments;
     NSString* peerConnectionId = argsMap[@"peerConnectionId"];
+    BOOL dispose = [@"peerConnectionDispose" isEqualToString:call.method];
 
     RTCPeerConnection* peerConnection = self.peerConnections[peerConnectionId];
     if (peerConnection) {
+      // Closing twice is harmless, the native peer connection ignores the second call.
       [peerConnection close];
-      [peerConnection.eventChannel setStreamHandler:nil];
-      peerConnection.eventChannel = nil;
-      [self.peerConnections removeObjectForKey:peerConnectionId];
 
       // Clean up peerConnection's streams and tracks
       [peerConnection.remoteStreams removeAllObjects];
       [peerConnection.remoteTracks removeAllObjects];
 
-      // Clean up peerConnection's dataChannels.
+      // Stop delivering data channel events. There is no need to close the
+      // RTCDataChannel because it is owned by the RTCPeerConnection and the
+      // latter will close the former.
       NSMutableDictionary<NSString*, RTCDataChannel*>* dataChannels = peerConnection.dataChannels;
       for (NSString* dataChannelId in dataChannels) {
         dataChannels[dataChannelId].delegate = nil;
-        [dataChannels[dataChannelId].eventChannel setStreamHandler:nil];
-        dataChannels[dataChannelId].eventChannel = nil;
-        // There is no need to close the RTCDataChannel because it is owned by the
-        // RTCPeerConnection and the latter will close the former.
       }
-      [dataChannels removeAllObjects];
+
+      if (dispose) {
+        // Release the event channel stream handlers only on dispose. The Dart
+        // side cancels its event subscription right before it calls dispose, and
+        // that cancel is a method call on the same channel. Releasing the handler
+        // on close would leave that cancel with no handler to answer it, which
+        // surfaces as a MissingPluginException for callers that close first and
+        // dispose later. The peer connection stays registered until dispose so
+        // the handlers can still be released at that point.
+        for (NSString* dataChannelId in dataChannels) {
+          [dataChannels[dataChannelId].eventChannel setStreamHandler:nil];
+          dataChannels[dataChannelId].eventChannel = nil;
+        }
+        [dataChannels removeAllObjects];
+        [peerConnection.eventChannel setStreamHandler:nil];
+        peerConnection.eventChannel = nil;
+        [self.peerConnections removeObjectForKey:peerConnectionId];
+      }
     }
     [self deactiveRtcAudioSession];
     result(nil);

--- a/common/darwin/Classes/FlutterWebRTCPlugin.m
+++ b/common/darwin/Classes/FlutterWebRTCPlugin.m
@@ -1951,12 +1951,24 @@ static void FlutterWebRTCApplyFieldTrials(void) {
 #endif
 }
 
+- (BOOL)hasOpenPeerConnection {
+  // A closed peer connection stays registered until it is disposed so that its
+  // event channel handler can be released at that point. It should not keep the
+  // audio session alive in the meantime.
+  for (RTCPeerConnection* peerConnection in self.peerConnections.allValues) {
+    if (peerConnection.signalingState != RTCSignalingStateClosed) {
+      return YES;
+    }
+  }
+  return NO;
+}
+
 - (void)deactiveRtcAudioSession {
 #if TARGET_OS_IPHONE
   if (!self.audioSessionManagementEnabled) {
     return;
   }
-  if (![self hasLocalAudioTrack] && self.peerConnections.count == 0) {
+  if (![self hasLocalAudioTrack] && ![self hasOpenPeerConnection]) {
     [AudioUtils deactiveRtcAudioSession];
   }
 #endif

--- a/lib/src/native/rtc_peerconnection_impl.dart
+++ b/lib/src/native/rtc_peerconnection_impl.dart
@@ -293,6 +293,14 @@ class RTCPeerConnectionNative extends RTCPeerConnection {
 
   @override
   Future<void> dispose() async {
+    // Cancel the event subscription before telling the platform to dispose.
+    // Cancelling sends a `cancel` method call on the event channel, and the
+    // native side releases that channel's stream handler when it handles
+    // peerConnectionDispose. The two messages travel on the same messenger
+    // and the `cancel` is sent synchronously inside the cancel callback, so
+    // it reaches the platform first. Keep this order. Swapping the two
+    // statements makes Flutter report a MissingPluginException for `cancel`
+    // on every teardown. See test/unit/rtc_peerconnection_dispose_order_test.dart.
     await _eventSubscription?.cancel();
     await WebRTC.invokeMethod(
       'peerConnectionDispose',

--- a/test/unit/rtc_peerconnection_dispose_order_test.dart
+++ b/test/unit/rtc_peerconnection_dispose_order_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/services.dart';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:flutter_webrtc/src/native/rtc_peerconnection_impl.dart';
+
+/// Pins the platform-channel call order that the darwin native plugin
+/// relies on when a peer connection is torn down.
+///
+/// close() invokes peerConnectionClose, and dispose() must cancel the
+/// event channel subscription before it invokes peerConnectionDispose.
+/// The darwin plugin only releases the event channel's stream handler
+/// on peerConnectionDispose, so if cancel is sent after (or is skipped
+/// before) that call, the platform side is already gone and Flutter
+/// reports a MissingPluginException for the event channel's cancel
+/// method instead of tearing down cleanly.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const peerConnectionId = 'pc-order-test';
+  final methodChannel = MethodChannel('FlutterWebRTC.Method');
+  final eventChannel =
+      MethodChannel('FlutterWebRTC/peerConnectionEvent$peerConnectionId');
+
+  final calls = <String>[];
+
+  setUp(() {
+    calls.clear();
+    methodChannel.setMockMethodCallHandler((MethodCall methodCall) async {
+      calls.add(methodCall.method);
+      return null;
+    });
+    eventChannel.setMockMethodCallHandler((MethodCall methodCall) async {
+      calls.add('event:${methodCall.method}');
+      return null;
+    });
+  });
+
+  tearDown(() {
+    methodChannel.setMockMethodCallHandler(null);
+    eventChannel.setMockMethodCallHandler(null);
+  });
+
+  test('close then dispose cancels the event subscription before disposing',
+      () async {
+    final pc = RTCPeerConnectionNative(peerConnectionId, {});
+
+    // Let the constructor's subscription reach the platform side.
+    await Future<void>.delayed(Duration.zero);
+
+    await pc.close();
+    await pc.dispose();
+
+    // Flush again so the async cancel/dispose calls are fully recorded.
+    await Future<void>.delayed(Duration.zero);
+
+    expect(calls, contains('peerConnectionClose'));
+    expect(calls, contains('event:listen'));
+    expect(calls, contains('event:cancel'));
+    expect(calls, contains('peerConnectionDispose'));
+
+    expect(
+        calls.indexOf('event:listen'), lessThan(calls.indexOf('event:cancel')));
+    expect(calls.indexOf('event:cancel'),
+        lessThan(calls.indexOf('peerConnectionDispose')));
+  });
+}

--- a/test/unit/rtc_peerconnection_dispose_order_test.dart
+++ b/test/unit/rtc_peerconnection_dispose_order_test.dart
@@ -10,10 +10,10 @@ import 'package:flutter_webrtc/src/native/rtc_peerconnection_impl.dart';
 /// close() invokes peerConnectionClose, and dispose() must cancel the
 /// event channel subscription before it invokes peerConnectionDispose.
 /// The darwin plugin only releases the event channel's stream handler
-/// on peerConnectionDispose, so if cancel is sent after (or is skipped
-/// before) that call, the platform side is already gone and Flutter
-/// reports a MissingPluginException for the event channel's cancel
-/// method instead of tearing down cleanly.
+/// on peerConnectionDispose. If cancel reached the platform after that
+/// call, the handler would already be gone and Flutter would report a
+/// MissingPluginException for the event channel's cancel method instead
+/// of tearing down cleanly.
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -51,7 +51,8 @@ void main() {
     await pc.close();
     await pc.dispose();
 
-    // Flush again so the async cancel/dispose calls are fully recorded.
+    // Both calls are recorded synchronously by the mock handlers while
+    // dispose() is awaited. Yield once more anyway so nothing is left pending.
     await Future<void>.delayed(Duration.zero);
 
     expect(calls, contains('peerConnectionClose'));


### PR DESCRIPTION
## Motivation

Since #2167 the darwin plugin releases the peer connection and data channel event channel stream handlers inside the block shared by `peerConnectionClose` and `peerConnectionDispose`. The Dart `RTCPeerConnection` contract is `close()` followed by `dispose()`, and `dispose()` cancels its event subscription before invoking native. That cancel is a method call on the same channel, so with the handler already gone Flutter reports on every teardown, once per peer connection:

```
MissingPluginException(No implementation found for method cancel on channel FlutterWebRTC/peerConnectionEvent<id>)
```

`livekit_client` calls `close()` then `dispose()` and hits this on every room disconnect on iOS and macOS with 1.6.2+hotfix.1. Android and the desktop C++ plugin already release the handler only on dispose.

## Summary

- `peerConnectionClose` still closes the connection, clears remote streams and tracks, and detaches data channel delegates. It no longer releases the stream handlers or removes the connection from the map.
- `peerConnectionDispose` releases the handlers and removes the connection, so the leak fix from #2167 still holds for every caller that disposes.
- Audio session deactivation ignores connections the plugin has closed, tracked with a `closedByPlugin` flag rather than a blocking `signalingState` read, so callers that only ever `close()` keep deactivating the session at the same point as before.
- Adds a Dart unit test that pins the `cancel` before `peerConnectionDispose` order the native side relies on, and a comment in `dispose()` explaining it.

## Behavior notes for reviewers

- A caller that only ever calls `close()` and never `dispose()` keeps the connection and its handler registered. That is the pre-#2167 behavior for such callers. Every Dart code path in this repo disposes.
- Between `close()` and `dispose()` the connection is still registered, so `getStats` returns an empty report instead of a "peerConnection is nil" error, and track lookups can still see stopped transceivers. Checked against libwebrtc: `Close()` early-returns when already closed, signaling state is `kClosed` synchronously after close, and no delegate callbacks fire after `close` returns.
- Residual, not introduced here: a data channel closed by the app after `pc.dispose()` still produces the same exception on its own channel. #2175 in this stack closes channels inside `dispose()`, which removes that path for apps that rely on dispose.

## Testing

- iOS simulator, iPhone 17 Pro, example `DataChannelLoopBackSample` with hang-up changed to `close()` then `dispose()` per connection, two call and hang-up cycles. On 1.6.2+hotfix.1 the log shows the `MissingPluginException` once per peer connection on every hang-up. On this stack the same cycles log nothing.
- `clang -fsyntax-only` for iOS and macOS on the changed files.
- `flutter test test/unit/` passes. The new test fails when the two statements in `dispose()` are swapped.
